### PR TITLE
Code clean up, update strip_model, start adding new geometries

### DIFF
--- a/create_DOE_prototype_building/measure.rb
+++ b/create_DOE_prototype_building/measure.rb
@@ -1,95 +1,95 @@
 
 # Start the measure
 class CreateDOEPrototypeBuilding < OpenStudio::Ruleset::ModelUserScript
-  
+
   # Define the name of the Measure.
   def name
-    return "Create DOE Prototype Building"
+    return 'Create DOE Prototype Building'
   end
 
   # Human readable description
   def description
-    return ""
+    return ''
   end
 
   # Human readable description of modeling approach
   def modeler_description
-    return ""
+    return ''
   end
-  
+
   # Define the arguments that the user will input.
   def arguments(model)
     args = OpenStudio::Ruleset::OSArgumentVector.new
-    
+
     # Make an argument for the building type
     building_type_chs = OpenStudio::StringVector.new
-    building_type_chs << "SecondarySchool"
-    building_type_chs << "SmallOffice"
+    building_type_chs << 'SecondarySchool'
+    building_type_chs << 'SmallOffice'
     building_type = OpenStudio::Ruleset::OSArgument::makeChoiceArgument('building_type', building_type_chs, true)
-    building_type.setDisplayName("Select a Building Type.")
-    building_type.setDefaultValue("SmallOffice")
+    building_type.setDisplayName('Select a Building Type.')
+    building_type.setDefaultValue('SmallOffice')
     args << building_type
 
     # Make an argument for the building vintage
     building_vintage_chs = OpenStudio::StringVector.new
-    building_vintage_chs << "DOE Ref Pre-1980"
-    building_vintage_chs << "DOE Ref 1980-2004"
-    #building_vintage_chs << "DOE Ref 2004"
-    #building_vintage_chs << "90.1-2007"
-    #building_vintage_chs << "189.1-2009"
-    building_vintage_chs << "90.1-2010"
+    building_vintage_chs << 'DOE Ref Pre-1980'
+    building_vintage_chs << 'DOE Ref 1980-2004'
+    #building_vintage_chs << 'DOE Ref 2004'
+    #building_vintage_chs << '90.1-2007'
+    #building_vintage_chs << '189.1-2009'
+    building_vintage_chs << '90.1-2010'
     building_vintage = OpenStudio::Ruleset::OSArgument::makeChoiceArgument('building_vintage', building_vintage_chs, true)
-    building_vintage.setDisplayName("Select a Vintage.")
-    building_vintage.setDefaultValue("90.1-2010")
-    args << building_vintage    
+    building_vintage.setDisplayName('Select a Vintage.')
+    building_vintage.setDefaultValue('90.1-2010')
+    args << building_vintage
 
     # Make an argument for the climate zone
     climate_zone_chs = OpenStudio::StringVector.new
-    #climate_zone_chs << "ASHRAE 169-2006-1A"
-    #climate_zone_chs << "ASHRAE 169-2006-1B"
-    climate_zone_chs << "ASHRAE 169-2006-2A"
-    #climate_zone_chs << "ASHRAE 169-2006-2B"
-    #climate_zone_chs << "ASHRAE 169-2006-3A"
-    climate_zone_chs << "ASHRAE 169-2006-3B"
-    #climate_zone_chs << "ASHRAE 169-2006-3C"
-    climate_zone_chs << "ASHRAE 169-2006-4A"
-    #climate_zone_chs << "ASHRAE 169-2006-4B"
-    #climate_zone_chs << "ASHRAE 169-2006-4C"
-    climate_zone_chs << "ASHRAE 169-2006-5A"
-    #climate_zone_chs << "ASHRAE 169-2006-5B"
-    #climate_zone_chs << "ASHRAE 169-2006-5C"
-    #climate_zone_chs << "ASHRAE 169-2006-6A"
-    #climate_zone_chs << "ASHRAE 169-2006-6B"
-    #climate_zone_chs << "ASHRAE 169-2006-7A"
-    #climate_zone_chs << "ASHRAE 169-2006-7B"
-    #climate_zone_chs << "ASHRAE 169-2006-8A"
-    #climate_zone_chs << "ASHRAE 169-2006-8B"
+    #climate_zone_chs << 'ASHRAE 169-2006-1A'
+    #climate_zone_chs << 'ASHRAE 169-2006-1B'
+    climate_zone_chs << 'ASHRAE 169-2006-2A'
+    #climate_zone_chs << 'ASHRAE 169-2006-2B'
+    #climate_zone_chs << 'ASHRAE 169-2006-3A'
+    climate_zone_chs << 'ASHRAE 169-2006-3B'
+    #climate_zone_chs << 'ASHRAE 169-2006-3C'
+    climate_zone_chs << 'ASHRAE 169-2006-4A'
+    #climate_zone_chs << 'ASHRAE 169-2006-4B'
+    #climate_zone_chs << 'ASHRAE 169-2006-4C'
+    climate_zone_chs << 'ASHRAE 169-2006-5A'
+    #climate_zone_chs << 'ASHRAE 169-2006-5B'
+    #climate_zone_chs << 'ASHRAE 169-2006-5C'
+    #climate_zone_chs << 'ASHRAE 169-2006-6A'
+    #climate_zone_chs << 'ASHRAE 169-2006-6B'
+    #climate_zone_chs << 'ASHRAE 169-2006-7A'
+    #climate_zone_chs << 'ASHRAE 169-2006-7B'
+    #climate_zone_chs << 'ASHRAE 169-2006-8A'
+    #climate_zone_chs << 'ASHRAE 169-2006-8B'
     climate_zone = OpenStudio::Ruleset::OSArgument::makeChoiceArgument('climate_zone', climate_zone_chs, true)
-    climate_zone.setDisplayName("Select a Climate Zone.")
-    climate_zone.setDefaultValue("ASHRAE 169-2006-2A")
-    args << climate_zone      
-    
+    climate_zone.setDisplayName('Select a Climate Zone.')
+    climate_zone.setDefaultValue('ASHRAE 169-2006-2A')
+    args << climate_zone
+
     return args
   end
 
   # Define what happens when the measure is run.
   def run(model, runner, user_arguments)
     super(model, runner, user_arguments)
-    
-    # Use the built-in error checking 
+
+    # Use the built-in error checking
     if not runner.validateUserArguments(arguments(model), user_arguments)
       return false
     end
 
     # Assign the user inputs to variables that can be accessed across the measure
-    building_type = runner.getStringArgumentValue("building_type",user_arguments)
-    building_vintage = runner.getStringArgumentValue("building_vintage",user_arguments)
-    climate_zone = runner.getStringArgumentValue("climate_zone",user_arguments)
+    building_type = runner.getStringArgumentValue('building_type',user_arguments)
+    building_vintage = runner.getStringArgumentValue('building_vintage',user_arguments)
+    climate_zone = runner.getStringArgumentValue('climate_zone',user_arguments)
 
     # Open a channel to log info/warning/error messages
     msg_log = OpenStudio::StringStreamLogSink.new
     msg_log.setLogLevel(OpenStudio::Info)
-    
+
     # Load the libraries
     # HVAC sizing
     require_relative 'resources/HVACSizing.Model'
@@ -99,89 +99,87 @@ class CreateDOEPrototypeBuilding < OpenStudio::Ruleset::ModelUserScript
     require_relative 'resources/Prototype.hvac_systems'
     require_relative 'resources/Prototype.Model'
     # Weather data
-    require_relative 'resources/Weather.Model'  
+    require_relative 'resources/Weather.Model'
     # HVAC standards
     require_relative 'resources/Standards.Model'
-    
+
     # Create a variable for the standard data directory
     # TODO Extend the OpenStudio::Model::Model class to store this
     # as an instance variable?
     standards_data_dir = "#{File.dirname(__FILE__)}/resources"
-    
+
     # Load the hvac standards from JSON
     hvac_standards_path = "#{File.dirname(__FILE__)}/resources/OpenStudio_HVAC_Standards.json"
     hvac_standards = {}
     temp = File.read(hvac_standards_path.to_s)
     hvac_standards = JSON.parse(temp)
     search_criteria = {
-      "template" => building_vintage,
-      "climate_zone" => climate_zone,
-      "building_type" => building_type,
+      'template' => building_vintage,
+      'climate_zone' => climate_zone,
+      'building_type' => building_type,
     }
-    
+
     # Load the Prototype Inputs from JSON
     prototype_input = find_object(hvac_standards["prototype_inputs"], search_criteria)
     if prototype_input.nil?
       runner.registerError("Could not find prototype inputs for #{search_criteria}, cannot create model.")
       return false
     end
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Creating #{building_type}-#{building_vintage}-#{climate_zone} with these inputs:")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Creating #{building_type}-#{building_vintage}-#{climate_zone} with these inputs:")
     prototype_input.each do |key, value|
-      OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "  #{key} = #{value}")
+      OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "  #{key} = #{value}")
     end
-     
+
     # Make a directory to save the resulting models for debugging
     build_dir = "#{Dir.pwd}/build"
     if !Dir.exists?(build_dir)
       Dir.mkdir(build_dir)
-    end    
-    
+    end
+
     osm_directory = "#{build_dir}/#{building_type}-#{building_vintage}-#{climate_zone}"
     if !Dir.exists?(osm_directory)
       Dir.mkdir(osm_directory)
     end
-    
+
     # Make the prototype building
+    building_type_search = building_type
+    has_swh = true
+
     case building_type
-    when "SecondarySchool"
+    when 'SecondarySchool'
       require_relative 'resources/Prototype.secondary_school'
-      model.add_geometry("Geometry.secondary_school.osm")
-      space_type_map = model.define_space_type_map
-      model.assign_space_type_stubs(building_type, space_type_map)
-      model.add_loads(building_vintage, climate_zone, standards_data_dir)
-      model.modify_infiltration_coefficients(building_type, building_vintage, climate_zone)
-      model.add_constructions(building_type, building_vintage, climate_zone, standards_data_dir)
-      model.create_thermal_zones
-      model.add_hvac(building_type, building_vintage, climate_zone, prototype_input, hvac_standards)
-      #swh_loop = model.add_swh_loop(prototype_input, hvac_standards)
-      #model.add_swh_end_uses(prototype_input, hvac_standards, swh_loop)
-      model.add_exterior_lights(building_type, building_vintage, climate_zone, prototype_input)
-      model.add_occupancy_sensors(building_type, building_vintage, climate_zone)    
-    when "SmallOffice"
+      geometry_file = 'Geometry.secondary_school.osm'
+      has_swh = false
+    when 'SmallOffice'
       require_relative 'resources/Prototype.small_office'
       # Small Office geometry is different for pre-1980
       # if has no attic, which means infiltration is way higher
       # since infiltration is specified per exposed exterior area.
-      if building_vintage == "DOE Ref Pre-1980"
-        model.add_geometry("Geometry.small_office_pre_1980.osm")
+      if building_vintage == 'DOE Ref Pre-1980'
+        geometry_file = 'Geometry.small_office_pre_1980.osm'
       else
-        model.add_geometry("Geometry.small_office.osm")
+        geometry_file = 'Geometry.small_office.osm'
       end
-      space_type_map = model.define_space_type_map
-      model.assign_space_type_stubs("Office", space_type_map)
-      model.add_loads(building_vintage, climate_zone, standards_data_dir)
-      model.modify_infiltration_coefficients(building_type, building_vintage, climate_zone)
-      model.add_constructions(building_type, building_vintage, climate_zone, standards_data_dir)
-      model.create_thermal_zones
-      model.add_hvac(building_type, building_vintage, climate_zone, prototype_input, hvac_standards)
-      swh_loop = model.add_swh_loop(prototype_input, hvac_standards)
-      model.add_swh_end_uses(prototype_input, hvac_standards, swh_loop)
-      model.add_exterior_lights(building_type, building_vintage, climate_zone, prototype_input)
-      model.add_occupancy_sensors(building_type, building_vintage, climate_zone)     
+      building_type_search = 'Office'
     else
-      OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model","Building Type = #{building_type} not recognized")
+      OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model',"Building Type = #{building_type} not recognized")
       return false
     end
+
+    model.add_geometry(geometry_file)
+    space_type_map = model.define_space_type_map
+    model.assign_space_type_stubs(building_type_search, space_type_map)
+    model.add_loads(building_vintage, climate_zone, standards_data_dir)
+    model.modify_infiltration_coefficients(building_type, building_vintage, climate_zone)
+    model.add_constructions(building_type, building_vintage, climate_zone, standards_data_dir)
+    model.create_thermal_zones
+    model.add_hvac(building_type, building_vintage, climate_zone, prototype_input, hvac_standards)
+    if has_swh
+      swh_loop = model.add_swh_loop(prototype_input, hvac_standards)
+      model.add_swh_end_uses(prototype_input, hvac_standards, swh_loop)
+    end
+    model.add_exterior_lights(building_type, building_vintage, climate_zone, prototype_input)
+    model.add_occupancy_sensors(building_type, building_vintage, climate_zone)
 
     # Set the building location, weather files, ddy files, etc.
     model.add_design_days_and_weather_file(climate_zone)
@@ -189,67 +187,67 @@ class CreateDOEPrototypeBuilding < OpenStudio::Ruleset::ModelUserScript
     # Assign the standards to the model
     model.template = building_vintage
     model.hvac_standards = hvac_standards
-    model_status = "1_initial_creation"
+    model_status = '1_initial_creation'
     #model.run("#{osm_directory}/#{model_status}")
     model.save(OpenStudio::Path.new("#{osm_directory}/#{model_status}.osm"), true)
-    
+
     # Perform a sizing run
     model.runSizingRun("#{osm_directory}/SizingRun1")
-    model_status = "2_after_first_sz_run"
+    model_status = '2_after_first_sz_run'
     #model.run("#{osm_directory}/#{model_status}")
     model.save(OpenStudio::Path.new("#{osm_directory}/#{model_status}.osm"), true)
-    
+
     # Retrieve only the fan flow rates and HX flow rates from the sizing run
     # and apply to the model.
     model.getFanConstantVolumes.sort.each {|obj| obj.applySizingValues}
     model.getFanVariableVolumes.sort.each {|obj| obj.applySizingValues}
     model.getHeatExchangerAirToAirSensibleAndLatents.sort.each {|obj| obj.applySizingValues}
-    model_status = "3_after_apply_fan_flows"
+    model_status = '3_after_apply_fan_flows'
     #model.run("#{osm_directory}/#{model_status}")
     model.save(OpenStudio::Path.new("#{osm_directory}/#{model_status}.osm"), true)
-    
+
     # Apply the prototype HVAC assumptions
     # which include sizing the fan pressure rises based
     # on the flow rate of the system.
     model.applyPrototypeHVACAssumptions
-    model_status = "4_after_proto_hvac_assumptions"
+    model_status = '4_after_proto_hvac_assumptions'
     #model.run("#{osm_directory}/#{model_status}")
     model.save(OpenStudio::Path.new("#{osm_directory}/#{model_status}.osm"), true)
-    
+
     # Perform a second sizing run. The adjusted fan pressure rises
     # impact the sizes of the heating coils.
-    model.runSizingRun("#{osm_directory}/SizingRun2")    
-    
+    model.runSizingRun("#{osm_directory}/SizingRun2")
+
     # Get the equipment sizes from the sizing run
     # and hard-assign them back to the model
     model.applySizingValues
-    model_status = "5_after_apply_sizes"
+    model_status = '5_after_apply_sizes'
     #model.run("#{osm_directory}/#{model_status}")
     model.save(OpenStudio::Path.new("#{osm_directory}/#{model_status}.osm"), true)
-    
+
     # Apply the HVAC efficiency standard
     model.applyHVACEfficiencyStandard
-    model_status = "6_after_apply_hvac_std"
+    model_status = '6_after_apply_hvac_std'
     #model.run("#{osm_directory}/#{model_status}")
     model.save(OpenStudio::Path.new("#{osm_directory}/#{model_status}.osm"), true)
-    
+
     # Add output variables for debugging
     model.request_timeseries_outputs
-    
+
     # Finished
-    model_status = "final"
+    model_status = 'final'
     #model.run("#{osm_directory}/#{model_status}")
     model.save(OpenStudio::Path.new("#{osm_directory}/#{model_status}.osm"), true)
 
     # Get all the log messages and put into output
     # for users to see.
     msg_log.logMessages.each do |msg|
-      # DLM: you can filter on log channel here for now 
+      # DLM: you can filter on log channel here for now
       if /openstudio\.model\..*/.match(msg.logChannel)
         # Skip the annoying/bogus "Skipping layer" warnings
-        next if msg.logMessage.include?("Skipping layer")
+        next if msg.logMessage.include?('Skipping layer')
         if msg.logLevel == OpenStudio::Info
-          runner.registerInfo(msg.logMessage)  
+          runner.registerInfo(msg.logMessage)
         elsif msg.logLevel == OpenStudio::Warn
           runner.registerWarning(msg.logMessage)
         elsif msg.logLevel == OpenStudio::Error
@@ -257,9 +255,9 @@ class CreateDOEPrototypeBuilding < OpenStudio::Ruleset::ModelUserScript
         end
       end
     end
-    
+
     return true
- 
+
   end #end the run method
 
 end #end the measure

--- a/create_DOE_prototype_building/measure.rb
+++ b/create_DOE_prototype_building/measure.rb
@@ -110,7 +110,6 @@ class CreateDOEPrototypeBuilding < OpenStudio::Ruleset::ModelUserScript
 
     # Load the hvac standards from JSON
     hvac_standards_path = "#{File.dirname(__FILE__)}/resources/OpenStudio_HVAC_Standards.json"
-    hvac_standards = {}
     temp = File.read(hvac_standards_path.to_s)
     hvac_standards = JSON.parse(temp)
     search_criteria = {
@@ -120,7 +119,7 @@ class CreateDOEPrototypeBuilding < OpenStudio::Ruleset::ModelUserScript
     }
 
     # Load the Prototype Inputs from JSON
-    prototype_input = find_object(hvac_standards["prototype_inputs"], search_criteria)
+    prototype_input = find_object(hvac_standards['prototype_inputs'], search_criteria)
     if prototype_input.nil?
       runner.registerError("Could not find prototype inputs for #{search_criteria}, cannot create model.")
       return false
@@ -142,7 +141,7 @@ class CreateDOEPrototypeBuilding < OpenStudio::Ruleset::ModelUserScript
     end
 
     # Make the prototype building
-    building_type_search = building_type
+    space_building_type_search = building_type
     has_swh = true
 
     case building_type
@@ -160,7 +159,7 @@ class CreateDOEPrototypeBuilding < OpenStudio::Ruleset::ModelUserScript
       else
         geometry_file = 'Geometry.small_office.osm'
       end
-      building_type_search = 'Office'
+      space_building_type_search = 'Office'
     else
       OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model',"Building Type = #{building_type} not recognized")
       return false
@@ -168,7 +167,7 @@ class CreateDOEPrototypeBuilding < OpenStudio::Ruleset::ModelUserScript
 
     model.add_geometry(geometry_file)
     space_type_map = model.define_space_type_map
-    model.assign_space_type_stubs(building_type_search, space_type_map)
+    model.assign_space_type_stubs(space_building_type_search, space_type_map)
     model.add_loads(building_vintage, climate_zone, standards_data_dir)
     model.modify_infiltration_coefficients(building_type, building_vintage, climate_zone)
     model.add_constructions(building_type, building_vintage, climate_zone, standards_data_dir)

--- a/create_DOE_prototype_building/resources/Geometry.medium_office.osm
+++ b/create_DOE_prototype_building/resources/Geometry.medium_office.osm
@@ -1,0 +1,4381 @@
+
+OS:Version,
+  {22ba3f6c-f80f-41e5-8a22-9e2c546bf251}, !- Handle
+  1.5.0;                                  !- Version Identifier
+
+OS:Site,
+  {4401af15-c546-44f8-96c5-410b73437a27}, !- Handle
+  USA IL-CHICAGO-OHARE,                   !- Name
+  41.77,                                  !- Latitude {deg}
+  -87.75,                                 !- Longitude {deg}
+  -6,                                     !- Time Zone {hr}
+  190,                                    !- Elevation {m}
+  City;                                   !- Terrain
+
+OS:SimulationControl,
+  {2134cbc1-5433-4c8c-b90e-bc63b05f2cae}, !- Handle
+  Yes,                                    !- Do Zone Sizing Calculation
+  Yes,                                    !- Do System Sizing Calculation
+  Yes,                                    !- Do Plant Sizing Calculation
+  Yes,                                    !- Run Simulation for Sizing Periods
+  No,                                     !- Run Simulation for Weather File Run Periods
+  0.04,                                   !- Loads Convergence Tolerance Value
+  0.2,                                    !- Temperature Convergence Tolerance Value {deltaC}
+  FullInteriorAndExterior,                !- Solar Distribution
+  25,                                     !- Maximum Number of Warmup Days
+  6;                                      !- Minimum Number of Warmup Days
+
+OS:Construction,
+  {d24f1e89-cddb-4b47-9c0b-ae2ec431c1a6}, !- Handle
+  INT-FLOOR-TOPSIDE,                      !- Name
+  ,                                       !- Surface Rendering Name
+  {b3c80cdc-2b06-42dd-be24-dc008b11a129}, !- Layer 1
+  {535ec96f-d298-4dcf-8ba2-7f023ecf3749}; !- Layer 2
+
+OS:Material,
+  {b3c80cdc-2b06-42dd-be24-dc008b11a129}, !- Handle
+  MAT-CC05 4 HW CONCRETE,                 !- Name
+  Rough,                                  !- Roughness
+  0.1016,                                 !- Thickness {m}
+  1.311,                                  !- Conductivity {W/m-K}
+  2240,                                   !- Density {kg/m3}
+  836.8,                                  !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:Material:NoMass,
+  {535ec96f-d298-4dcf-8ba2-7f023ecf3749}, !- Handle
+  CP02 CARPET PAD,                        !- Name
+  VeryRough,                              !- Roughness
+  0.2165,                                 !- Thermal Resistance {m2-K/W}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.8;                                    !- Visible Absorptance
+
+OS:Surface,
+  {084d45e2-b21a-428c-96c2-ab7001d364ad}, !- Handle
+  Perimeter_mid_ZN_4_Wall_North,          !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {fd517fa4-3c26-440a-aa97-3ace8c1c83b8}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {4de4d18e-cfa0-4a45-b7e2-061b3c5cc693}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  4.5732, 28.7006, 6.7056,                !- X,Y,Z Vertex 1 {m}
+  4.5732, 28.7006, 3.9624,                !- X,Y,Z Vertex 2 {m}
+  0, 33.2738, 3.9624,                     !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 6.7056;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Construction,
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Handle
+  int-walls,                              !- Name
+  ,                                       !- Surface Rendering Name
+  {8680bdef-55b0-46cb-ae20-1ca186008971}, !- Layer 1
+  {8680bdef-55b0-46cb-ae20-1ca186008971}; !- Layer 2
+
+OS:Material,
+  {8680bdef-55b0-46cb-ae20-1ca186008971}, !- Handle
+  1/2IN Gypsum,                           !- Name
+  Smooth,                                 !- Roughness
+  0.0127,                                 !- Thickness {m}
+  0.16,                                   !- Conductivity {W/m-K}
+  784.9,                                  !- Density {kg/m3}
+  830,                                    !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.92,                                   !- Solar Absorptance
+  0.92;                                   !- Visible Absorptance
+
+OS:ThermalZone,
+  {ca1e67b6-4bcb-4ed4-b8ec-f01173326252}, !- Handle
+  Perimeter_mid_ZN_4 Thermal Zone,        !- Name
+  1,                                      !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {94c14b54-684c-43b6-a447-7a86707fabc8}, !- Zone Air Inlet Port List
+  {5bb26712-a731-45a9-bdb3-4f3a9a32dbe6}, !- Zone Air Exhaust Port List
+  {3251a104-9178-462f-87a9-5bd4dc7a4421}, !- Zone Air Node Name
+  ,                                       !- Zone Return Air Node Name
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  ,                                       !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {2c26b6c1-b190-415a-a658-32e49e54c0ae}, !- Handle
+  {147044f1-36a2-4ae6-8f47-4fb1f5795d55}, !- Name
+  {3251a104-9178-462f-87a9-5bd4dc7a4421}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {3251a104-9178-462f-87a9-5bd4dc7a4421}, !- Handle
+  {a34e1b20-5b85-4001-910e-e99c193c9e37}, !- Name
+  {ca1e67b6-4bcb-4ed4-b8ec-f01173326252}, !- Source Object
+  11,                                     !- Outlet Port
+  {2c26b6c1-b190-415a-a658-32e49e54c0ae}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {94c14b54-684c-43b6-a447-7a86707fabc8}, !- Handle
+  {65183bb2-1f42-48f2-90bd-b10c4e03d654}, !- Name
+  {ca1e67b6-4bcb-4ed4-b8ec-f01173326252}; !- HVAC Component
+
+OS:PortList,
+  {5bb26712-a731-45a9-bdb3-4f3a9a32dbe6}, !- Handle
+  {f4da1ffd-4f90-48cf-9112-97527d69022f}, !- Name
+  {ca1e67b6-4bcb-4ed4-b8ec-f01173326252}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {74fb4f31-76c3-4e15-a74e-01999d0fbbc5}, !- Handle
+  {ca1e67b6-4bcb-4ed4-b8ec-f01173326252}, !- Zone or ZoneList Name
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+
+OS:ZoneHVAC:EquipmentList,
+  {a01e4027-a224-48f2-8675-d7375d20fae5}, !- Handle
+  {8102a49f-389c-4623-9ab4-87e1af870053}, !- Name
+  {ca1e67b6-4bcb-4ed4-b8ec-f01173326252}; !- Thermal Zone
+
+OS:Space,
+  {fd517fa4-3c26-440a-aa97-3ace8c1c83b8}, !- Handle
+  Perimeter_mid_ZN_4,                     !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  0,                                      !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  ,                                       !- Building Story Name
+  {ca1e67b6-4bcb-4ed4-b8ec-f01173326252}, !- Thermal Zone Name
+  Yes;                                    !- Part of Total Floor Area
+
+OS:Surface,
+  {6fda72e7-e9a3-456f-99d8-861fd64ce491}, !- Handle
+  Core_bot_ZN_5_Wall_South,               !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {0301d7f6-33a7-4967-9d2b-ab9b1cfbe5aa}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {850637cc-a8a1-4eba-b885-16d5d92d7986}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  4.5732, 4.5732, 2.7432,                 !- X,Y,Z Vertex 1 {m}
+  4.5732, 4.5732, 0,                      !- X,Y,Z Vertex 2 {m}
+  45.3375, 4.5732, 0,                     !- X,Y,Z Vertex 3 {m}
+  45.3375, 4.5732, 2.7432;                !- X,Y,Z Vertex 4 {m}
+
+OS:ThermalZone,
+  {f4479f0a-f42d-4f5b-bdb4-546af61310a5}, !- Handle
+  Core_bottom Thermal Zone,               !- Name
+  1,                                      !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {d6074603-de52-4d1e-a2f9-875f5ef74655}, !- Zone Air Inlet Port List
+  {edc70e32-87db-45e8-8a3d-4f5ed661bc9a}, !- Zone Air Exhaust Port List
+  {3997a087-aeb9-4f63-8af7-77219f3fcf60}, !- Zone Air Node Name
+  ,                                       !- Zone Return Air Node Name
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  ,                                       !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {614eacfb-cbc5-4e26-9d25-52257f88e20e}, !- Handle
+  {1164ef38-9d5a-4ffa-a984-949d734d912f}, !- Name
+  {3997a087-aeb9-4f63-8af7-77219f3fcf60}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {3997a087-aeb9-4f63-8af7-77219f3fcf60}, !- Handle
+  {a5b4f6bb-76ac-49ca-9714-ec400ef4073b}, !- Name
+  {f4479f0a-f42d-4f5b-bdb4-546af61310a5}, !- Source Object
+  11,                                     !- Outlet Port
+  {614eacfb-cbc5-4e26-9d25-52257f88e20e}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {d6074603-de52-4d1e-a2f9-875f5ef74655}, !- Handle
+  {e094500e-a528-4e7f-813e-9e2e9bbd902a}, !- Name
+  {f4479f0a-f42d-4f5b-bdb4-546af61310a5}; !- HVAC Component
+
+OS:PortList,
+  {edc70e32-87db-45e8-8a3d-4f5ed661bc9a}, !- Handle
+  {21a6ca4c-d1d2-4c01-8a5d-e6f13dba456a}, !- Name
+  {f4479f0a-f42d-4f5b-bdb4-546af61310a5}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {00615f75-3efa-4ba9-8f97-bf705eb01624}, !- Handle
+  {f4479f0a-f42d-4f5b-bdb4-546af61310a5}, !- Zone or ZoneList Name
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+
+OS:ZoneHVAC:EquipmentList,
+  {6786afdf-2307-4fb2-8362-e25156c3d610}, !- Handle
+  {8540e577-bffa-4223-8ddf-374efc7982bf}, !- Name
+  {f4479f0a-f42d-4f5b-bdb4-546af61310a5}; !- Thermal Zone
+
+OS:Space,
+  {0301d7f6-33a7-4967-9d2b-ab9b1cfbe5aa}, !- Handle
+  Core_bottom,                            !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  0,                                      !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  ,                                       !- Building Story Name
+  {f4479f0a-f42d-4f5b-bdb4-546af61310a5}, !- Thermal Zone Name
+  Yes;                                    !- Part of Total Floor Area
+
+OS:Surface,
+  {ed837c7d-a8d1-48a6-8eef-6bed72d42925}, !- Handle
+  FirstFloor_Plenum_Ceiling_4,            !- Name
+  RoofCeiling,                            !- Surface Type
+  {d2639f93-4cc4-4eee-90ec-1f31812be744}, !- Construction Name
+  {af409fa8-d6d1-4cb3-ab07-78dd65cb9800}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {3edb3dc0-7f5c-4e0f-8598-412854bf4412}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 3.9624,                           !- X,Y,Z Vertex 1 {m}
+  4.5732, 4.5732, 3.9624,                 !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 3.9624,                !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 3.9624;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Construction,
+  {d2639f93-4cc4-4eee-90ec-1f31812be744}, !- Handle
+  INT-FLOOR-UNDERSIDE,                    !- Name
+  ,                                       !- Surface Rendering Name
+  {535ec96f-d298-4dcf-8ba2-7f023ecf3749}, !- Layer 1
+  {b3c80cdc-2b06-42dd-be24-dc008b11a129}; !- Layer 2
+
+OS:ThermalZone,
+  {c00902d7-caf2-45d0-93fe-279735e99ddd}, !- Handle
+  FirstFloor_Plenum Thermal Zone,         !- Name
+  1,                                      !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {8bd2b5de-0445-432f-ae2d-f5cc01a9c951}, !- Zone Air Inlet Port List
+  {25965147-148c-497e-a985-c9e363e2e5ef}, !- Zone Air Exhaust Port List
+  {9374b6d9-4d54-48ce-a7eb-cec45d1eb92e}, !- Zone Air Node Name
+  ,                                       !- Zone Return Air Node Name
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  ,                                       !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {6fe3a559-910b-435b-9a1e-ee43861cda88}, !- Handle
+  {fe902992-4fd0-4ddb-8163-27fb28e3000b}, !- Name
+  {9374b6d9-4d54-48ce-a7eb-cec45d1eb92e}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {9374b6d9-4d54-48ce-a7eb-cec45d1eb92e}, !- Handle
+  {91c1062b-20ef-48be-b1d8-36df762b49ba}, !- Name
+  {c00902d7-caf2-45d0-93fe-279735e99ddd}, !- Source Object
+  11,                                     !- Outlet Port
+  {6fe3a559-910b-435b-9a1e-ee43861cda88}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {8bd2b5de-0445-432f-ae2d-f5cc01a9c951}, !- Handle
+  {7316cf2f-10a2-4d31-a169-49da850f19e6}, !- Name
+  {c00902d7-caf2-45d0-93fe-279735e99ddd}; !- HVAC Component
+
+OS:PortList,
+  {25965147-148c-497e-a985-c9e363e2e5ef}, !- Handle
+  {003eea4a-d2ff-49ff-86b0-ac63e8d449b9}, !- Name
+  {c00902d7-caf2-45d0-93fe-279735e99ddd}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {3aca3388-971a-438d-8fd7-2c021c20be1a}, !- Handle
+  {c00902d7-caf2-45d0-93fe-279735e99ddd}, !- Zone or ZoneList Name
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+
+OS:ZoneHVAC:EquipmentList,
+  {ffd09fe9-24d3-4b60-9175-45c611df3ade}, !- Handle
+  {e960a09b-e541-46d8-8e68-423e52f8511e}, !- Name
+  {c00902d7-caf2-45d0-93fe-279735e99ddd}; !- Thermal Zone
+
+OS:Space,
+  {af409fa8-d6d1-4cb3-ab07-78dd65cb9800}, !- Handle
+  FirstFloor_Plenum,                      !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  0,                                      !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  ,                                       !- Building Story Name
+  {c00902d7-caf2-45d0-93fe-279735e99ddd}, !- Thermal Zone Name
+  No;                                     !- Part of Total Floor Area
+
+OS:Surface,
+  {8bbd4623-f911-4cfe-8a43-7c3e7e31f8df}, !- Handle
+  Perimeter_top_Plenum_Wall_West,         !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {a6db022f-dfaa-45fa-9573-a2cb4bec5f66}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 33.2738, 11.8872,                    !- X,Y,Z Vertex 1 {m}
+  0, 33.2738, 10.668,                     !- X,Y,Z Vertex 2 {m}
+  0, 0, 10.668,                           !- X,Y,Z Vertex 3 {m}
+  0, 0, 11.8872;                          !- X,Y,Z Vertex 4 {m}
+
+OS:Construction,
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Handle
+  Steel Frame Non-res Ext Wall,           !- Name
+  ,                                       !- Surface Rendering Name
+  {98110651-d979-4e50-8ca3-8373b0411be4}, !- Layer 1
+  {db9fbe95-0888-42ef-867e-66b452fc973f}, !- Layer 2
+  {8680bdef-55b0-46cb-ae20-1ca186008971}; !- Layer 3
+
+OS:Material,
+  {98110651-d979-4e50-8ca3-8373b0411be4}, !- Handle
+  Wood Siding,                            !- Name
+  MediumSmooth,                           !- Roughness
+  0.01,                                   !- Thickness {m}
+  0.11,                                   !- Conductivity {W/m-K}
+  544.62,                                 !- Density {kg/m3}
+  1210,                                   !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.78,                                   !- Solar Absorptance
+  0.78;                                   !- Visible Absorptance
+
+OS:Material,
+  {db9fbe95-0888-42ef-867e-66b452fc973f}, !- Handle
+  Steel Frame NonRes Wall Insulation,     !- Name
+  MediumRough,                            !- Roughness
+  0.0870564552646045,                     !- Thickness {m}
+  0.049,                                  !- Conductivity {W/m-K}
+  265,                                    !- Density {kg/m3}
+  836.8,                                  !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:ThermalZone,
+  {922cc324-3f20-40f2-98cc-db0b6a4da580}, !- Handle
+  TopFloor_Plenum Thermal Zone,           !- Name
+  1,                                      !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {51f230a3-baf7-48aa-8ccb-fca6b4dca7ca}, !- Zone Air Inlet Port List
+  {75ad801b-3a96-442c-8368-55a70442938f}, !- Zone Air Exhaust Port List
+  {c3560cee-15d4-46d3-8e14-7961e8c7a634}, !- Zone Air Node Name
+  ,                                       !- Zone Return Air Node Name
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  ,                                       !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {466ab0c9-409e-48b9-8e4d-15798c3391c8}, !- Handle
+  {8c46a74a-e2bc-4b3f-98b8-5f1bd4e4555c}, !- Name
+  {c3560cee-15d4-46d3-8e14-7961e8c7a634}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {c3560cee-15d4-46d3-8e14-7961e8c7a634}, !- Handle
+  {dfa5c0cc-e1e7-424f-a80c-e433ac49c8fb}, !- Name
+  {922cc324-3f20-40f2-98cc-db0b6a4da580}, !- Source Object
+  11,                                     !- Outlet Port
+  {466ab0c9-409e-48b9-8e4d-15798c3391c8}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {51f230a3-baf7-48aa-8ccb-fca6b4dca7ca}, !- Handle
+  {7177f303-6394-4214-8429-765ddbfae3f9}, !- Name
+  {922cc324-3f20-40f2-98cc-db0b6a4da580}; !- HVAC Component
+
+OS:PortList,
+  {75ad801b-3a96-442c-8368-55a70442938f}, !- Handle
+  {7a5f5831-3476-4914-b072-bc7164bfdbbd}, !- Name
+  {922cc324-3f20-40f2-98cc-db0b6a4da580}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {ac74d09d-ad73-4259-b8fa-1fbc1b65fd44}, !- Handle
+  {922cc324-3f20-40f2-98cc-db0b6a4da580}, !- Zone or ZoneList Name
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+
+OS:ZoneHVAC:EquipmentList,
+  {767a9173-5f29-46af-98e7-d37350088da8}, !- Handle
+  {c0b7f760-aac5-46eb-8079-b0060a93a19c}, !- Name
+  {922cc324-3f20-40f2-98cc-db0b6a4da580}; !- Thermal Zone
+
+OS:Space,
+  {a6db022f-dfaa-45fa-9573-a2cb4bec5f66}, !- Handle
+  TopFloor_Plenum,                        !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  0,                                      !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  ,                                       !- Building Story Name
+  {922cc324-3f20-40f2-98cc-db0b6a4da580}, !- Thermal Zone Name
+  No;                                     !- Part of Total Floor Area
+
+OS:Surface,
+  {b90242e8-7039-45eb-a313-1beb1f893fcb}, !- Handle
+  Perimeter_top_ZN_3_Wall_North,          !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {67aa5b71-cfb3-4a14-86b6-9f9ba9a407f8}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 10.668,                !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 7.9248,                !- X,Y,Z Vertex 2 {m}
+  0, 33.2738, 7.9248,                     !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 10.668;                     !- X,Y,Z Vertex 4 {m}
+
+OS:ThermalZone,
+  {7529a3ad-d0c6-496d-926f-fd53c70ee767}, !- Handle
+  Perimeter_top_ZN_3 Thermal Zone,        !- Name
+  1,                                      !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {dbb1bf29-13ee-4f38-98ea-61e36191ae65}, !- Zone Air Inlet Port List
+  {6f19aa70-d0b0-4e9c-b6e8-ec0d9092f889}, !- Zone Air Exhaust Port List
+  {afe10e32-b72d-4d5e-bf54-2826ba05b467}, !- Zone Air Node Name
+  ,                                       !- Zone Return Air Node Name
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  ,                                       !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {f46c9682-e18c-410f-97d2-c17fe2e0aeec}, !- Handle
+  {eff4f6aa-9aaa-4e70-a55e-288375832d6a}, !- Name
+  {afe10e32-b72d-4d5e-bf54-2826ba05b467}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {afe10e32-b72d-4d5e-bf54-2826ba05b467}, !- Handle
+  {2d982968-6e53-4520-ae27-0ab10bba98b3}, !- Name
+  {7529a3ad-d0c6-496d-926f-fd53c70ee767}, !- Source Object
+  11,                                     !- Outlet Port
+  {f46c9682-e18c-410f-97d2-c17fe2e0aeec}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {dbb1bf29-13ee-4f38-98ea-61e36191ae65}, !- Handle
+  {d974a5a9-d797-4eac-adf7-0dee78553d9c}, !- Name
+  {7529a3ad-d0c6-496d-926f-fd53c70ee767}; !- HVAC Component
+
+OS:PortList,
+  {6f19aa70-d0b0-4e9c-b6e8-ec0d9092f889}, !- Handle
+  {7b29e495-f096-4358-b737-a143f9dca74b}, !- Name
+  {7529a3ad-d0c6-496d-926f-fd53c70ee767}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {26d8f873-8605-4ddb-87ca-37907d0b4a08}, !- Handle
+  {7529a3ad-d0c6-496d-926f-fd53c70ee767}, !- Zone or ZoneList Name
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+
+OS:ZoneHVAC:EquipmentList,
+  {04775d04-6f1d-40c4-b3ca-ab07251b1567}, !- Handle
+  {55cc7b30-f863-47e5-afea-eedcaa27e54a}, !- Name
+  {7529a3ad-d0c6-496d-926f-fd53c70ee767}; !- Thermal Zone
+
+OS:Space,
+  {67aa5b71-cfb3-4a14-86b6-9f9ba9a407f8}, !- Handle
+  Perimeter_top_ZN_3,                     !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  0,                                      !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  ,                                       !- Building Story Name
+  {7529a3ad-d0c6-496d-926f-fd53c70ee767}, !- Thermal Zone Name
+  Yes;                                    !- Part of Total Floor Area
+
+OS:Surface,
+  {8f228f71-0dc3-4dc5-8a8b-630b8c9a5571}, !- Handle
+  Perimeter_bot_ZN_2_Wall_East,           !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {a20d9a0e-f1f9-4c21-938a-707c85783069}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 2.7432,                      !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 0,                           !- X,Y,Z Vertex 2 {m}
+  49.911, 33.2738, 0,                     !- X,Y,Z Vertex 3 {m}
+  49.911, 33.2738, 2.7432;                !- X,Y,Z Vertex 4 {m}
+
+OS:ThermalZone,
+  {7cbc9dc8-1335-4744-a4ad-f9319138d3a6}, !- Handle
+  Perimeter_bot_ZN_2 Thermal Zone,        !- Name
+  1,                                      !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {9d5f923c-702f-4a88-b8b1-1844dd1284f7}, !- Zone Air Inlet Port List
+  {68c56e05-b94d-4179-a7e9-519d9151fa85}, !- Zone Air Exhaust Port List
+  {8648570b-75f8-4c43-8675-fd8884421cf9}, !- Zone Air Node Name
+  ,                                       !- Zone Return Air Node Name
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  ,                                       !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {085a23dc-7fab-4799-833f-a36562178a45}, !- Handle
+  {25b2adbe-da65-48cb-969e-51c57862de9b}, !- Name
+  {8648570b-75f8-4c43-8675-fd8884421cf9}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {8648570b-75f8-4c43-8675-fd8884421cf9}, !- Handle
+  {3767d3cc-1c29-4eaa-a8e5-c8e9afb466de}, !- Name
+  {7cbc9dc8-1335-4744-a4ad-f9319138d3a6}, !- Source Object
+  11,                                     !- Outlet Port
+  {085a23dc-7fab-4799-833f-a36562178a45}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {9d5f923c-702f-4a88-b8b1-1844dd1284f7}, !- Handle
+  {f0813298-ddf0-48e6-a459-f5e047c682e0}, !- Name
+  {7cbc9dc8-1335-4744-a4ad-f9319138d3a6}; !- HVAC Component
+
+OS:PortList,
+  {68c56e05-b94d-4179-a7e9-519d9151fa85}, !- Handle
+  {b4c2cf92-03af-4469-89f3-4637573e9a6c}, !- Name
+  {7cbc9dc8-1335-4744-a4ad-f9319138d3a6}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {bc6ba715-d0e1-4b52-b295-64530d55e9a1}, !- Handle
+  {7cbc9dc8-1335-4744-a4ad-f9319138d3a6}, !- Zone or ZoneList Name
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+
+OS:ZoneHVAC:EquipmentList,
+  {8304a124-967d-44c8-8981-1581f316a490}, !- Handle
+  {3cfeafe9-a8f6-4c22-ad63-82a3865333e4}, !- Name
+  {7cbc9dc8-1335-4744-a4ad-f9319138d3a6}; !- Thermal Zone
+
+OS:Space,
+  {a20d9a0e-f1f9-4c21-938a-707c85783069}, !- Handle
+  Perimeter_bot_ZN_2,                     !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  0,                                      !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  ,                                       !- Building Story Name
+  {7cbc9dc8-1335-4744-a4ad-f9319138d3a6}, !- Thermal Zone Name
+  Yes;                                    !- Part of Total Floor Area
+
+OS:Surface,
+  {63743c59-278b-4607-b2a3-29b9e0721532}, !- Handle
+  Perimeter_mid_Plenum_Wall_West,         !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {7b5df7a4-7bf7-4b0e-9c4c-233b5f3bc4d7}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 33.2738, 7.9248,                     !- X,Y,Z Vertex 1 {m}
+  0, 33.2738, 6.7056,                     !- X,Y,Z Vertex 2 {m}
+  0, 0, 6.7056,                           !- X,Y,Z Vertex 3 {m}
+  0, 0, 7.9248;                           !- X,Y,Z Vertex 4 {m}
+
+OS:ThermalZone,
+  {05e2de9b-8c3a-4f44-96e1-6b037e999d53}, !- Handle
+  MidFloor_Plenum Thermal Zone,           !- Name
+  1,                                      !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {3767b834-db2b-431b-80fa-fb09c34e2171}, !- Zone Air Inlet Port List
+  {a30adf4b-f5d8-46b3-aa6a-ee1c927ffd00}, !- Zone Air Exhaust Port List
+  {70c7c49f-9c3b-4432-948d-40f7dcdceb85}, !- Zone Air Node Name
+  ,                                       !- Zone Return Air Node Name
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  ,                                       !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {867f2e1c-26d3-490e-9025-8eec9a6b9798}, !- Handle
+  {c1649cea-7e22-4bae-af5c-e6fbf8fd18c5}, !- Name
+  {70c7c49f-9c3b-4432-948d-40f7dcdceb85}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {70c7c49f-9c3b-4432-948d-40f7dcdceb85}, !- Handle
+  {27f238d7-c984-49a3-a31d-8c158bc58e4a}, !- Name
+  {05e2de9b-8c3a-4f44-96e1-6b037e999d53}, !- Source Object
+  11,                                     !- Outlet Port
+  {867f2e1c-26d3-490e-9025-8eec9a6b9798}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {3767b834-db2b-431b-80fa-fb09c34e2171}, !- Handle
+  {812ae70a-4e6b-42fd-bc85-b3d520fe0237}, !- Name
+  {05e2de9b-8c3a-4f44-96e1-6b037e999d53}; !- HVAC Component
+
+OS:PortList,
+  {a30adf4b-f5d8-46b3-aa6a-ee1c927ffd00}, !- Handle
+  {783bd6d9-1758-4738-9c12-2547cd9b57a2}, !- Name
+  {05e2de9b-8c3a-4f44-96e1-6b037e999d53}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {7999a018-f1fe-45da-9a16-cb0f7e2864de}, !- Handle
+  {05e2de9b-8c3a-4f44-96e1-6b037e999d53}, !- Zone or ZoneList Name
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+
+OS:ZoneHVAC:EquipmentList,
+  {896517aa-1a13-42af-a421-b60496a3dccf}, !- Handle
+  {c5076795-4e24-4a4f-a229-83aa9bee082a}, !- Name
+  {05e2de9b-8c3a-4f44-96e1-6b037e999d53}; !- Thermal Zone
+
+OS:Space,
+  {7b5df7a4-7bf7-4b0e-9c4c-233b5f3bc4d7}, !- Handle
+  MidFloor_Plenum,                        !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  0,                                      !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  ,                                       !- Building Story Name
+  {05e2de9b-8c3a-4f44-96e1-6b037e999d53}, !- Thermal Zone Name
+  No;                                     !- Part of Total Floor Area
+
+OS:Material,
+  {85619a51-745f-4ee1-8f9c-35834ddf8cf7}, !- Handle
+  Roof Membrane,                          !- Name
+  VeryRough,                              !- Roughness
+  0.0095,                                 !- Thickness {m}
+  0.16,                                   !- Conductivity {W/m-K}
+  1121.29,                                !- Density {kg/m3}
+  1460,                                   !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:Surface,
+  {f7f1b951-dcee-4fa9-9929-19b2dd55275a}, !- Handle
+  Core_bot_ZN_5_Wall_East,                !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {0301d7f6-33a7-4967-9d2b-ab9b1cfbe5aa}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {21521d19-6c0b-4aaf-bdef-7a25819baa97}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 2.7432,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 0,                     !- X,Y,Z Vertex 2 {m}
+  45.3375, 28.7006, 0,                    !- X,Y,Z Vertex 3 {m}
+  45.3375, 28.7006, 2.7432;               !- X,Y,Z Vertex 4 {m}
+
+OS:ThermalZone,
+  {aa2dc5db-57c6-4daf-b30f-876621ad84be}, !- Handle
+  Perimeter_mid_ZN_1 Thermal Zone,        !- Name
+  1,                                      !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {ed241e2c-1f97-447f-8a9b-f32e5ec8b0b2}, !- Zone Air Inlet Port List
+  {fb07278b-8b8d-4fce-93c4-1d7e0112e009}, !- Zone Air Exhaust Port List
+  {5b4f233a-f867-4e28-b77f-a75223d01ab1}, !- Zone Air Node Name
+  ,                                       !- Zone Return Air Node Name
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  ,                                       !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {82249039-ed18-4973-b464-53eb8c286b7a}, !- Handle
+  {672cd246-d830-436a-94ab-9550fec5a1fc}, !- Name
+  {5b4f233a-f867-4e28-b77f-a75223d01ab1}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {5b4f233a-f867-4e28-b77f-a75223d01ab1}, !- Handle
+  {59e4d256-bcb2-4f19-b7a0-43ebd7ca0b4a}, !- Name
+  {aa2dc5db-57c6-4daf-b30f-876621ad84be}, !- Source Object
+  11,                                     !- Outlet Port
+  {82249039-ed18-4973-b464-53eb8c286b7a}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {ed241e2c-1f97-447f-8a9b-f32e5ec8b0b2}, !- Handle
+  {e84c13e7-4564-4c43-b718-bba37b16a882}, !- Name
+  {aa2dc5db-57c6-4daf-b30f-876621ad84be}; !- HVAC Component
+
+OS:PortList,
+  {fb07278b-8b8d-4fce-93c4-1d7e0112e009}, !- Handle
+  {85347492-654d-4bb1-893d-0c3e149d4483}, !- Name
+  {aa2dc5db-57c6-4daf-b30f-876621ad84be}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {464942c5-5183-4708-ad9e-6c172fd5eaee}, !- Handle
+  {aa2dc5db-57c6-4daf-b30f-876621ad84be}, !- Zone or ZoneList Name
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+
+OS:ZoneHVAC:EquipmentList,
+  {97643804-8225-47e9-ac90-3b6b8cb77a4f}, !- Handle
+  {35cd4251-0d1e-4677-9c31-13a34baddf7c}, !- Name
+  {aa2dc5db-57c6-4daf-b30f-876621ad84be}; !- Thermal Zone
+
+OS:Space,
+  {bcf7adbf-62d7-4451-bd90-23e37f8bd918}, !- Handle
+  Perimeter_mid_ZN_1,                     !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  0,                                      !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  ,                                       !- Building Story Name
+  {aa2dc5db-57c6-4daf-b30f-876621ad84be}, !- Thermal Zone Name
+  Yes;                                    !- Part of Total Floor Area
+
+OS:ThermalZone,
+  {87e846f6-62c0-468a-a173-07d46723b340}, !- Handle
+  Perimeter_bot_ZN_1 Thermal Zone,        !- Name
+  1,                                      !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {208a1608-3854-47d9-841e-05dcc0b2537d}, !- Zone Air Inlet Port List
+  {ead252d6-1271-477f-bb74-c85903b82397}, !- Zone Air Exhaust Port List
+  {1075df3e-244e-4e8c-9ecb-3835a6dcd57e}, !- Zone Air Node Name
+  ,                                       !- Zone Return Air Node Name
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  ,                                       !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {e673e6e9-cace-409d-ae85-682b84a67be9}, !- Handle
+  {98626edb-e05b-4efa-9b64-5c6d85a61189}, !- Name
+  {1075df3e-244e-4e8c-9ecb-3835a6dcd57e}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {1075df3e-244e-4e8c-9ecb-3835a6dcd57e}, !- Handle
+  {c7a79ba8-5df7-4625-8813-3c03c43e80d9}, !- Name
+  {87e846f6-62c0-468a-a173-07d46723b340}, !- Source Object
+  11,                                     !- Outlet Port
+  {e673e6e9-cace-409d-ae85-682b84a67be9}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {208a1608-3854-47d9-841e-05dcc0b2537d}, !- Handle
+  {d88aaa9a-c1b9-41a4-800e-327a2da3e01f}, !- Name
+  {87e846f6-62c0-468a-a173-07d46723b340}; !- HVAC Component
+
+OS:PortList,
+  {ead252d6-1271-477f-bb74-c85903b82397}, !- Handle
+  {f0f0da25-b469-432a-b3ab-a10ce0919ee1}, !- Name
+  {87e846f6-62c0-468a-a173-07d46723b340}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {0afda558-5f56-403c-95e8-c2f6afe5f852}, !- Handle
+  {87e846f6-62c0-468a-a173-07d46723b340}, !- Zone or ZoneList Name
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+
+OS:ZoneHVAC:EquipmentList,
+  {1f9318e8-6b7d-4682-bc79-c2229391ed60}, !- Handle
+  {7a154652-3ff7-42e0-a860-46e12320571e}, !- Name
+  {87e846f6-62c0-468a-a173-07d46723b340}; !- Thermal Zone
+
+OS:Space,
+  {dac06210-f4a7-4108-99da-b010224bcaf1}, !- Handle
+  Perimeter_bot_ZN_1,                     !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  0,                                      !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  ,                                       !- Building Story Name
+  {87e846f6-62c0-468a-a173-07d46723b340}, !- Thermal Zone Name
+  Yes;                                    !- Part of Total Floor Area
+
+OS:Surface,
+  {ff6a02f2-f53d-444f-98b8-0a577fc698a1}, !- Handle
+  Perimeter_mid_ZN_1_Wall_West,           !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {bcf7adbf-62d7-4451-bd90-23e37f8bd918}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {64e092f7-fac8-4c55-94b6-f063d55be81f}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  4.5732, 4.5732, 6.7056,                 !- X,Y,Z Vertex 1 {m}
+  4.5732, 4.5732, 3.9624,                 !- X,Y,Z Vertex 2 {m}
+  0, 0, 3.9624,                           !- X,Y,Z Vertex 3 {m}
+  0, 0, 6.7056;                           !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {c4c69e54-2157-4950-8388-5e464612dd2b}, !- Handle
+  Perimeter_bot_ZN_3_Wall_North,          !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {c7f6e37f-54b9-4246-b00b-8ba5739f031d}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 2.7432,                !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 33.2738, 0,                          !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 2.7432;                     !- X,Y,Z Vertex 4 {m}
+
+OS:ThermalZone,
+  {13d25c8e-3a75-404c-99b2-fdb8552a2bb8}, !- Handle
+  Perimeter_bot_ZN_3 Thermal Zone,        !- Name
+  1,                                      !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {3c6e672d-d8f0-4f6d-a0c7-152617325fa6}, !- Zone Air Inlet Port List
+  {4372db35-fade-4a14-ad02-4026a9d307c9}, !- Zone Air Exhaust Port List
+  {48349877-a319-4bb0-a75b-701ab9ce8476}, !- Zone Air Node Name
+  ,                                       !- Zone Return Air Node Name
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  ,                                       !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {081387ca-b7b1-4b48-b062-f32250dd92c3}, !- Handle
+  {c920f6c1-4a0f-4d51-9483-f113cd44235e}, !- Name
+  {48349877-a319-4bb0-a75b-701ab9ce8476}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {48349877-a319-4bb0-a75b-701ab9ce8476}, !- Handle
+  {192384f3-e080-4c16-80e9-652a030eeca3}, !- Name
+  {13d25c8e-3a75-404c-99b2-fdb8552a2bb8}, !- Source Object
+  11,                                     !- Outlet Port
+  {081387ca-b7b1-4b48-b062-f32250dd92c3}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {3c6e672d-d8f0-4f6d-a0c7-152617325fa6}, !- Handle
+  {6cd185bd-70c0-4fa9-9273-288d36a07e69}, !- Name
+  {13d25c8e-3a75-404c-99b2-fdb8552a2bb8}; !- HVAC Component
+
+OS:PortList,
+  {4372db35-fade-4a14-ad02-4026a9d307c9}, !- Handle
+  {6cf63043-39b6-4276-ac7f-0590d76ef081}, !- Name
+  {13d25c8e-3a75-404c-99b2-fdb8552a2bb8}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {b0eb1f35-ea3e-4be4-9df9-617a08eaeb0d}, !- Handle
+  {13d25c8e-3a75-404c-99b2-fdb8552a2bb8}, !- Zone or ZoneList Name
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+
+OS:ZoneHVAC:EquipmentList,
+  {296e2656-c0aa-4cc5-8d55-0c98226f231a}, !- Handle
+  {c9e39b8e-fe99-4d07-8976-59351a07c782}, !- Name
+  {13d25c8e-3a75-404c-99b2-fdb8552a2bb8}; !- Thermal Zone
+
+OS:Space,
+  {c7f6e37f-54b9-4246-b00b-8ba5739f031d}, !- Handle
+  Perimeter_bot_ZN_3,                     !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  0,                                      !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  ,                                       !- Building Story Name
+  {13d25c8e-3a75-404c-99b2-fdb8552a2bb8}, !- Thermal Zone Name
+  Yes;                                    !- Part of Total Floor Area
+
+OS:Surface,
+  {366cd017-9214-406c-bf3a-de5e4e5f5140}, !- Handle
+  Perimeter_mid_ZN_2_Wall_North,          !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {722a09e4-0646-4e5a-b78d-58b632bc69f7}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {507f3231-1a82-4997-afd8-1cb4825c2dfa}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 6.7056,                !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 3.9624,                !- X,Y,Z Vertex 2 {m}
+  45.3375, 28.7006, 3.9624,               !- X,Y,Z Vertex 3 {m}
+  45.3375, 28.7006, 6.7056;               !- X,Y,Z Vertex 4 {m}
+
+OS:ThermalZone,
+  {6bb95f65-d646-4f38-a08f-042ea92a6a51}, !- Handle
+  Perimeter_mid_ZN_2 Thermal Zone,        !- Name
+  1,                                      !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {d4c4f6e4-dc1a-4cd9-8022-2102244e7ce6}, !- Zone Air Inlet Port List
+  {111eeb2f-8965-452d-94cd-76e15aa06ecd}, !- Zone Air Exhaust Port List
+  {c74d23b7-90c7-4c8d-9eae-736c6bbd98a2}, !- Zone Air Node Name
+  ,                                       !- Zone Return Air Node Name
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  ,                                       !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {f7954eb5-2ae1-422c-b98d-c5e88b4fa288}, !- Handle
+  {eb167e9b-a3b1-48d7-997c-ed8bdd1fb3b2}, !- Name
+  {c74d23b7-90c7-4c8d-9eae-736c6bbd98a2}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {c74d23b7-90c7-4c8d-9eae-736c6bbd98a2}, !- Handle
+  {ae3fead7-c6f7-42ed-a9ff-abe6c3ada941}, !- Name
+  {6bb95f65-d646-4f38-a08f-042ea92a6a51}, !- Source Object
+  11,                                     !- Outlet Port
+  {f7954eb5-2ae1-422c-b98d-c5e88b4fa288}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {d4c4f6e4-dc1a-4cd9-8022-2102244e7ce6}, !- Handle
+  {bb3cc2e4-e054-4dad-98d6-ce80df38d3c5}, !- Name
+  {6bb95f65-d646-4f38-a08f-042ea92a6a51}; !- HVAC Component
+
+OS:PortList,
+  {111eeb2f-8965-452d-94cd-76e15aa06ecd}, !- Handle
+  {129bc18e-5e8e-44c3-a73c-c51e595c2d86}, !- Name
+  {6bb95f65-d646-4f38-a08f-042ea92a6a51}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {4cca6d47-b399-4f07-9a8c-d64ba6066041}, !- Handle
+  {6bb95f65-d646-4f38-a08f-042ea92a6a51}, !- Zone or ZoneList Name
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+
+OS:ZoneHVAC:EquipmentList,
+  {03b5679d-a694-4f05-8655-24e29b56aec4}, !- Handle
+  {3cf91d46-97a3-4cdc-ada0-cd6b8307c939}, !- Name
+  {6bb95f65-d646-4f38-a08f-042ea92a6a51}; !- Thermal Zone
+
+OS:Space,
+  {722a09e4-0646-4e5a-b78d-58b632bc69f7}, !- Handle
+  Perimeter_mid_ZN_2,                     !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  0,                                      !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  ,                                       !- Building Story Name
+  {6bb95f65-d646-4f38-a08f-042ea92a6a51}, !- Thermal Zone Name
+  Yes;                                    !- Part of Total Floor Area
+
+OS:Surface,
+  {c9895b27-179a-4471-9ab3-f80539d3a631}, !- Handle
+  Perimeter_top_ZN_3_Wall_West,           !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {67aa5b71-cfb3-4a14-86b6-9f9ba9a407f8}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {0eade2fb-cfbc-458f-aab2-a32566bec56d}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 33.2738, 10.668,                     !- X,Y,Z Vertex 1 {m}
+  0, 33.2738, 7.9248,                     !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 7.9248,                !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 10.668;                !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {1f334cca-8215-49da-b5fa-8d073dc6ef54}, !- Handle
+  Perimeter_mid_ZN_4_Wall_West_Window,    !- Name
+  FixedWindow,                            !- Sub Surface Type
+  {1bc32cfb-af5e-403d-a471-8f5c989f4a11}, !- Construction Name
+  {3b007fc4-a7ea-4d54-a7c1-0b39798c8e32}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  1,                                      !- Multiplier
+  ,                                       !- Number of Vertices
+  0, 33.2737, 6.2917,                     !- X,Y,Z Vertex 1 {m}
+  0, 33.2737, 4.9837,                     !- X,Y,Z Vertex 2 {m}
+  0, 0, 4.9837,                           !- X,Y,Z Vertex 3 {m}
+  0, 0, 6.2917;                           !- X,Y,Z Vertex 4 {m}
+
+OS:Construction,
+  {1bc32cfb-af5e-403d-a471-8f5c989f4a11}, !- Handle
+  Window Non-res Fixed,                   !- Name
+  ,                                       !- Surface Rendering Name
+  {bd07e97d-30c3-44c9-ab63-dfb9820c24e0}; !- Layer 1
+
+OS:WindowMaterial:SimpleGlazingSystem,
+  {bd07e97d-30c3-44c9-ab63-dfb9820c24e0}, !- Handle
+  NonRes Fixed Assembly Window,           !- Name
+  3.23646,                                !- U-Factor {W/m2-K}
+  0.39;                                   !- Solar Heat Gain Coefficient
+
+OS:Surface,
+  {3b007fc4-a7ea-4d54-a7c1-0b39798c8e32}, !- Handle
+  Perimeter_mid_ZN_4_Wall_West,           !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {fd517fa4-3c26-440a-aa97-3ace8c1c83b8}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 33.2738, 6.7056,                     !- X,Y,Z Vertex 1 {m}
+  0, 33.2738, 3.9624,                     !- X,Y,Z Vertex 2 {m}
+  0, 0, 3.9624,                           !- X,Y,Z Vertex 3 {m}
+  0, 0, 6.7056;                           !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {61d12225-bce5-4b99-80ed-34e17a0a5b59}, !- Handle
+  Perimeter_top_ZN_4_Wall_South,          !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {a47d34ed-7efc-47ea-bdaa-671d58f47564}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {2a5440cd-ea85-4103-b898-e494c25a3868}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 10.668,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 7.9248,                           !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 7.9248,                 !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 10.668;                 !- X,Y,Z Vertex 4 {m}
+
+OS:ThermalZone,
+  {119976b1-3960-45cb-bb3a-2ef171becd56}, !- Handle
+  Perimeter_top_ZN_4 Thermal Zone,        !- Name
+  1,                                      !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {58e51d2a-1cd9-4394-b2e4-b7677147b63f}, !- Zone Air Inlet Port List
+  {24514148-698f-44ae-87ae-ae0f794a6629}, !- Zone Air Exhaust Port List
+  {3ac71dba-513d-4610-8b96-a1499245af91}, !- Zone Air Node Name
+  ,                                       !- Zone Return Air Node Name
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  ,                                       !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {5cdbb0c2-b3c8-4886-95b4-019259ff0e93}, !- Handle
+  {cac74b7a-6be0-4d02-b1b5-5ec91dbd456b}, !- Name
+  {3ac71dba-513d-4610-8b96-a1499245af91}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {3ac71dba-513d-4610-8b96-a1499245af91}, !- Handle
+  {125040e3-a269-48e9-8312-919f9659a926}, !- Name
+  {119976b1-3960-45cb-bb3a-2ef171becd56}, !- Source Object
+  11,                                     !- Outlet Port
+  {5cdbb0c2-b3c8-4886-95b4-019259ff0e93}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {58e51d2a-1cd9-4394-b2e4-b7677147b63f}, !- Handle
+  {f0c61f59-05e3-4479-a43c-713297f62cc3}, !- Name
+  {119976b1-3960-45cb-bb3a-2ef171becd56}; !- HVAC Component
+
+OS:PortList,
+  {24514148-698f-44ae-87ae-ae0f794a6629}, !- Handle
+  {b0f3bbc1-e99a-4bec-80ff-a2a2d4c866fb}, !- Name
+  {119976b1-3960-45cb-bb3a-2ef171becd56}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {9960966d-0bcf-4969-a835-35261a455b80}, !- Handle
+  {119976b1-3960-45cb-bb3a-2ef171becd56}, !- Zone or ZoneList Name
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+
+OS:ZoneHVAC:EquipmentList,
+  {fab36325-2a1c-464c-9570-4665a182c9eb}, !- Handle
+  {01f24f2e-bde7-4081-a8c0-06c8e6f4b495}, !- Name
+  {119976b1-3960-45cb-bb3a-2ef171becd56}; !- Thermal Zone
+
+OS:Space,
+  {a47d34ed-7efc-47ea-bdaa-671d58f47564}, !- Handle
+  Perimeter_top_ZN_4,                     !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  0,                                      !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  ,                                       !- Building Story Name
+  {119976b1-3960-45cb-bb3a-2ef171becd56}, !- Thermal Zone Name
+  Yes;                                    !- Part of Total Floor Area
+
+OS:Surface,
+  {aa582faa-13da-4f36-a518-5e93d04ec017}, !- Handle
+  Perimeter_bot_ZN_1_Floor,               !- Name
+  Floor,                                  !- Surface Type
+  {4f011101-a6b7-4cde-98e5-2d67029d02d0}, !- Construction Name
+  {dac06210-f4a7-4108-99da-b010224bcaf1}, !- Space Name
+  Ground,                                 !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 0,                     !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 0;                      !- X,Y,Z Vertex 4 {m}
+
+OS:Construction,
+  {4f011101-a6b7-4cde-98e5-2d67029d02d0}, !- Handle
+  ext-slab,                               !- Name
+  ,                                       !- Surface Rendering Name
+  {2f704391-6ac3-4a88-be44-534e3498b53e}, !- Layer 1
+  {535ec96f-d298-4dcf-8ba2-7f023ecf3749}; !- Layer 2
+
+OS:Material,
+  {2f704391-6ac3-4a88-be44-534e3498b53e}, !- Handle
+  HW CONCRETE,                            !- Name
+  Rough,                                  !- Roughness
+  0.1016,                                 !- Thickness {m}
+  1.311,                                  !- Conductivity {W/m-K}
+  2240,                                   !- Density {kg/m3}
+  836.8,                                  !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:Surface,
+  {bf1bdda1-7ff2-4daa-aa1f-4437429b5ee4}, !- Handle
+  Perimeter_bot_ZN_4_Wall_East,           !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {27fdb3c4-855f-48df-983a-24f85fe57204}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {4f0eee25-7cf0-4c5a-8f95-6e0c5d25448c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  4.5732, 4.5732, 2.7432,                 !- X,Y,Z Vertex 1 {m}
+  4.5732, 4.5732, 0,                      !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 0,                     !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 2.7432;                !- X,Y,Z Vertex 4 {m}
+
+OS:ThermalZone,
+  {c82c95b7-0736-43f1-a8bb-2a0a9017221b}, !- Handle
+  Perimeter_bot_ZN_4 Thermal Zone,        !- Name
+  1,                                      !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {5d084b88-83f1-4d0c-9740-5f8ed094d691}, !- Zone Air Inlet Port List
+  {57496a37-9e37-4835-b626-c7b1d134cac3}, !- Zone Air Exhaust Port List
+  {d867664e-8bbb-4857-8fa5-fa5e58516137}, !- Zone Air Node Name
+  ,                                       !- Zone Return Air Node Name
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  ,                                       !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {8d3baf96-d151-4bfb-a792-f30c0f1046af}, !- Handle
+  {03736d70-39de-4af8-9fe7-242e3682a7c2}, !- Name
+  {d867664e-8bbb-4857-8fa5-fa5e58516137}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {d867664e-8bbb-4857-8fa5-fa5e58516137}, !- Handle
+  {04e66276-502f-4d83-a247-2ab0a2d944c7}, !- Name
+  {c82c95b7-0736-43f1-a8bb-2a0a9017221b}, !- Source Object
+  11,                                     !- Outlet Port
+  {8d3baf96-d151-4bfb-a792-f30c0f1046af}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {5d084b88-83f1-4d0c-9740-5f8ed094d691}, !- Handle
+  {ba6fead6-4737-4515-850e-6a00004675ff}, !- Name
+  {c82c95b7-0736-43f1-a8bb-2a0a9017221b}; !- HVAC Component
+
+OS:PortList,
+  {57496a37-9e37-4835-b626-c7b1d134cac3}, !- Handle
+  {085cb2c6-8cbe-4810-9396-9ebe797f8afa}, !- Name
+  {c82c95b7-0736-43f1-a8bb-2a0a9017221b}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {d6498def-476f-41fd-9c3e-348188382108}, !- Handle
+  {c82c95b7-0736-43f1-a8bb-2a0a9017221b}, !- Zone or ZoneList Name
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+
+OS:ZoneHVAC:EquipmentList,
+  {fb8b92a5-d891-465b-9bfe-167509bfda84}, !- Handle
+  {133c28e0-73bd-4267-8142-d84d957579d5}, !- Name
+  {c82c95b7-0736-43f1-a8bb-2a0a9017221b}; !- Thermal Zone
+
+OS:Space,
+  {27fdb3c4-855f-48df-983a-24f85fe57204}, !- Handle
+  Perimeter_bot_ZN_4,                     !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  0,                                      !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  ,                                       !- Building Story Name
+  {c82c95b7-0736-43f1-a8bb-2a0a9017221b}, !- Thermal Zone Name
+  Yes;                                    !- Part of Total Floor Area
+
+OS:Surface,
+  {198f6abb-f3b4-46fc-977c-806261fd2cf6}, !- Handle
+  Core_bot_ZN_5_Floor,                    !- Name
+  Floor,                                  !- Surface Type
+  {4f011101-a6b7-4cde-98e5-2d67029d02d0}, !- Construction Name
+  {0301d7f6-33a7-4967-9d2b-ab9b1cfbe5aa}, !- Space Name
+  Ground,                                 !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 0,                    !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 0,                     !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 0,                      !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 0;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Material,
+  {804292cc-ff21-4a9c-afeb-e2b37e35019b}, !- Handle
+  IEAD NonRes Roof Insulation,            !- Name
+  MediumRough,                            !- Roughness
+  0.127338688569477,                      !- Thickness {m}
+  0.049,                                  !- Conductivity {W/m-K}
+  265,                                    !- Density {kg/m3}
+  836.8,                                  !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:Surface,
+  {453dc878-1de9-49ce-a86e-0a3e48dd74cb}, !- Handle
+  MidFloor_Plenum_Floor_3,                !- Name
+  Floor,                                  !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {7b5df7a4-7bf7-4b0e-9c4c-233b5f3bc4d7}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {7d103038-a362-4dd4-886b-b11bfdd870a4}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 6.7056,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 6.7056,               !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 6.7056,                !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 6.7056;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Construction,
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Handle
+  DropCeiling,                            !- Name
+  ,                                       !- Surface Rendering Name
+  {33b5ae1c-db33-46ba-99db-387603d098ea}; !- Layer 1
+
+OS:Material,
+  {33b5ae1c-db33-46ba-99db-387603d098ea}, !- Handle
+  Std AC02,                               !- Name
+  MediumSmooth,                           !- Roughness
+  0.0127,                                 !- Thickness {m}
+  0.057,                                  !- Conductivity {W/m-K}
+  288,                                    !- Density {kg/m3}
+  1339,                                   !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.2;                                    !- Visible Absorptance
+
+OS:Material:NoMass,
+  {9f09ba8b-23c0-4911-8c51-2077115d9238}, !- Handle
+  MAT-AIR-WALL,                           !- Name
+  Rough,                                  !- Roughness
+  0.2079491,                              !- Thermal Resistance {m2-K/W}
+  0.9,                                    !- Thermal Absorptance
+  0.7;                                    !- Solar Absorptance
+
+OS:Surface,
+  {2112c288-4f79-47d5-a164-06bbbec3d999}, !- Handle
+  Core_top_ZN_5_Wall_South,               !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {b422ea64-bad8-4f36-9616-c0c97070580c}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {88c74cf5-8639-441e-8899-481ea739e404}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  4.5732, 4.5732, 10.668,                 !- X,Y,Z Vertex 1 {m}
+  4.5732, 4.5732, 7.9248,                 !- X,Y,Z Vertex 2 {m}
+  45.3375, 4.5732, 7.9248,                !- X,Y,Z Vertex 3 {m}
+  45.3375, 4.5732, 10.668;                !- X,Y,Z Vertex 4 {m}
+
+OS:ThermalZone,
+  {33f90219-72c1-46ee-8ef9-24ec1a2547ab}, !- Handle
+  Core_top Thermal Zone,                  !- Name
+  1,                                      !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {716a5c0c-89b1-4ff6-8b88-879e36ccb5b7}, !- Zone Air Inlet Port List
+  {c2b19712-3989-48a2-9472-74371b33013f}, !- Zone Air Exhaust Port List
+  {386b236d-87cf-4c51-a865-7efaae1a1371}, !- Zone Air Node Name
+  ,                                       !- Zone Return Air Node Name
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  ,                                       !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {9770ad0a-e9bd-4817-b50b-e664b2dafe0f}, !- Handle
+  {b52c9c2e-dde2-4b8a-bd79-f30edb425b53}, !- Name
+  {386b236d-87cf-4c51-a865-7efaae1a1371}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {386b236d-87cf-4c51-a865-7efaae1a1371}, !- Handle
+  {c856817e-1774-48e9-9a76-eac1f951338c}, !- Name
+  {33f90219-72c1-46ee-8ef9-24ec1a2547ab}, !- Source Object
+  11,                                     !- Outlet Port
+  {9770ad0a-e9bd-4817-b50b-e664b2dafe0f}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {716a5c0c-89b1-4ff6-8b88-879e36ccb5b7}, !- Handle
+  {f27ca883-9065-4b82-bbed-a3d6d64b7dc8}, !- Name
+  {33f90219-72c1-46ee-8ef9-24ec1a2547ab}; !- HVAC Component
+
+OS:PortList,
+  {c2b19712-3989-48a2-9472-74371b33013f}, !- Handle
+  {47515ab0-a327-4902-b0e2-32cf71ecd17d}, !- Name
+  {33f90219-72c1-46ee-8ef9-24ec1a2547ab}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {ef114d50-a9bb-46e3-a766-6e933439c208}, !- Handle
+  {33f90219-72c1-46ee-8ef9-24ec1a2547ab}, !- Zone or ZoneList Name
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+
+OS:ZoneHVAC:EquipmentList,
+  {59677f07-ed19-4802-8247-d38ae3fed2bf}, !- Handle
+  {7f67f828-0d2a-4845-a34f-2891b2711f52}, !- Name
+  {33f90219-72c1-46ee-8ef9-24ec1a2547ab}; !- Thermal Zone
+
+OS:Space,
+  {b422ea64-bad8-4f36-9616-c0c97070580c}, !- Handle
+  Core_top,                               !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  0,                                      !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  ,                                       !- Building Story Name
+  {33f90219-72c1-46ee-8ef9-24ec1a2547ab}, !- Thermal Zone Name
+  Yes;                                    !- Part of Total Floor Area
+
+OS:Surface,
+  {92fc0069-37f1-4f1d-8565-c516a771ba37}, !- Handle
+  Perimeter_top_Plenum_Wall_North,        !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {a6db022f-dfaa-45fa-9573-a2cb4bec5f66}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 11.8872,               !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 10.668,                !- X,Y,Z Vertex 2 {m}
+  0, 33.2738, 10.668,                     !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 11.8872;                    !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {17f19611-089d-40f4-a913-e72440fee3e6}, !- Handle
+  MidFloor_Plenum_Ceiling_3,              !- Name
+  RoofCeiling,                            !- Surface Type
+  {d2639f93-4cc4-4eee-90ec-1f31812be744}, !- Construction Name
+  {7b5df7a4-7bf7-4b0e-9c4c-233b5f3bc4d7}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {88ccce13-3ada-47fc-b4d8-5248dc1dadde}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 7.9248,               !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 7.9248,                !- X,Y,Z Vertex 2 {m}
+  0, 33.2738, 7.9248,                     !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 7.9248;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {49211562-7b70-470e-b1a2-79aeb11ef499}, !- Handle
+  Perimeter_top_ZN_4_Wall_East,           !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {a47d34ed-7efc-47ea-bdaa-671d58f47564}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {7b1703fe-1a29-4c1d-811a-5a82464bc284}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  4.5732, 4.5732, 10.668,                 !- X,Y,Z Vertex 1 {m}
+  4.5732, 4.5732, 7.9248,                 !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 7.9248,                !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 10.668;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {914d9885-c299-4083-a7f6-1500ca96db2f}, !- Handle
+  TopFloor_Plenum_Floor_4,                !- Name
+  Floor,                                  !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {a6db022f-dfaa-45fa-9573-a2cb4bec5f66}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {2c105491-2cb6-417d-8943-ad87b1c2fc11}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 33.2738, 10.668,                     !- X,Y,Z Vertex 1 {m}
+  4.5732, 28.7006, 10.668,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 10.668,                 !- X,Y,Z Vertex 3 {m}
+  0, 0, 10.668;                           !- X,Y,Z Vertex 4 {m}
+
+OS:Material,
+  {329936e5-23e3-439b-976c-12d4fb26c14d}, !- Handle
+  Metal Siding,                           !- Name
+  Smooth,                                 !- Roughness
+  0.0015,                                 !- Thickness {m}
+  44.96,                                  !- Conductivity {W/m-K}
+  7688.86,                                !- Density {kg/m3}
+  410,                                    !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.2,                                    !- Solar Absorptance
+  0.2;                                    !- Visible Absorptance
+
+OS:SubSurface,
+  {ad046e3f-42ed-49dd-a6d8-b4a5639f4279}, !- Handle
+  Perimeter_bot_ZN_2_Wall_East_Window,    !- Name
+  FixedWindow,                            !- Sub Surface Type
+  {1bc32cfb-af5e-403d-a471-8f5c989f4a11}, !- Construction Name
+  {8f228f71-0dc3-4dc5-8a8b-630b8c9a5571}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  1,                                      !- Multiplier
+  ,                                       !- Number of Vertices
+  49.911, 0, 2.3293,                      !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 1.0213,                      !- X,Y,Z Vertex 2 {m}
+  49.911, 33.2737, 1.0213,                !- X,Y,Z Vertex 3 {m}
+  49.911, 33.2737, 2.3293;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {87e0c255-21c8-4ad8-a88b-59d2b89d337b}, !- Handle
+  Perimeter_top_ZN_2_Wall_South,          !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {eb32a2fb-5981-48a3-a152-e410cbe800cd}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {5a783f68-56f1-4c37-b5ad-498e9a045418}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 10.668,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 7.9248,                !- X,Y,Z Vertex 2 {m}
+  49.911, 0, 7.9248,                      !- X,Y,Z Vertex 3 {m}
+  49.911, 0, 10.668;                      !- X,Y,Z Vertex 4 {m}
+
+OS:ThermalZone,
+  {0bdbbc6a-6aea-463f-8d70-7bed625876fc}, !- Handle
+  Perimeter_top_ZN_2 Thermal Zone,        !- Name
+  1,                                      !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {9a595f7c-5cc3-4949-82fd-c601d879b0b8}, !- Zone Air Inlet Port List
+  {279edf94-48da-4736-921b-8a9fa63a5a93}, !- Zone Air Exhaust Port List
+  {7dff4d08-8dca-4d9d-a4e9-ae9e455d6704}, !- Zone Air Node Name
+  ,                                       !- Zone Return Air Node Name
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  ,                                       !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {07d62fe1-b40a-44dc-ac6a-90ea1f3c57cd}, !- Handle
+  {58951e6b-5b05-46ee-9b5b-562b1f28d708}, !- Name
+  {7dff4d08-8dca-4d9d-a4e9-ae9e455d6704}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {7dff4d08-8dca-4d9d-a4e9-ae9e455d6704}, !- Handle
+  {498e129e-0912-4645-a5b4-6d8125082d8f}, !- Name
+  {0bdbbc6a-6aea-463f-8d70-7bed625876fc}, !- Source Object
+  11,                                     !- Outlet Port
+  {07d62fe1-b40a-44dc-ac6a-90ea1f3c57cd}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {9a595f7c-5cc3-4949-82fd-c601d879b0b8}, !- Handle
+  {a129e5dd-31d0-43d9-b383-050388e157c3}, !- Name
+  {0bdbbc6a-6aea-463f-8d70-7bed625876fc}; !- HVAC Component
+
+OS:PortList,
+  {279edf94-48da-4736-921b-8a9fa63a5a93}, !- Handle
+  {31b116f2-4037-490f-a80a-da35e89374e5}, !- Name
+  {0bdbbc6a-6aea-463f-8d70-7bed625876fc}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {946dbd1f-cde1-4422-9b2d-ef49cff220f8}, !- Handle
+  {0bdbbc6a-6aea-463f-8d70-7bed625876fc}, !- Zone or ZoneList Name
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+
+OS:ZoneHVAC:EquipmentList,
+  {dc314f0f-9774-45d4-8be6-58fe9aca340d}, !- Handle
+  {32f419e5-b82e-4545-a2dc-22e83042f76b}, !- Name
+  {0bdbbc6a-6aea-463f-8d70-7bed625876fc}; !- Thermal Zone
+
+OS:Space,
+  {eb32a2fb-5981-48a3-a152-e410cbe800cd}, !- Handle
+  Perimeter_top_ZN_2,                     !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  0,                                      !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  ,                                       !- Building Story Name
+  {0bdbbc6a-6aea-463f-8d70-7bed625876fc}, !- Thermal Zone Name
+  Yes;                                    !- Part of Total Floor Area
+
+OS:Surface,
+  {d6273170-f5e5-41d7-919f-8167938886ad}, !- Handle
+  Perimeter_bot_ZN_2_Ceiling,             !- Name
+  RoofCeiling,                            !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {a20d9a0e-f1f9-4c21-938a-707c85783069}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {79c19edf-9c28-4804-a251-5943f81cbcee}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 2.7432,                      !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 2.7432,                !- X,Y,Z Vertex 2 {m}
+  45.3375, 28.7006, 2.7432,               !- X,Y,Z Vertex 3 {m}
+  45.3375, 4.5732, 2.7432;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {f04af906-2489-4213-b0b8-d08ad8487886}, !- Handle
+  Perimeter_bot_Plenum_Wall_West,         !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {af409fa8-d6d1-4cb3-ab07-78dd65cb9800}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 33.2738, 3.9624,                     !- X,Y,Z Vertex 1 {m}
+  0, 33.2738, 2.7432,                     !- X,Y,Z Vertex 2 {m}
+  0, 0, 2.7432,                           !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.9624;                           !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {576d1f61-9b9f-4ad0-95e7-c20abfa77214}, !- Handle
+  Perimeter_bot_ZN_4_Wall_North,          !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {27fdb3c4-855f-48df-983a-24f85fe57204}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {96c0d38b-45dd-4d4d-83ed-7371f075cf56}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  4.5732, 28.7006, 2.7432,                !- X,Y,Z Vertex 1 {m}
+  4.5732, 28.7006, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 33.2738, 0,                          !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 2.7432;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {57a170ff-8fbc-4d8e-bde1-b1f6a3991342}, !- Handle
+  MidFloor_Plenum_Ceiling_4,              !- Name
+  RoofCeiling,                            !- Surface Type
+  {d2639f93-4cc4-4eee-90ec-1f31812be744}, !- Construction Name
+  {7b5df7a4-7bf7-4b0e-9c4c-233b5f3bc4d7}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {8660326f-4758-4779-bab8-6ba75b8988f6}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 7.9248,                           !- X,Y,Z Vertex 1 {m}
+  4.5732, 4.5732, 7.9248,                 !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 7.9248,                !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 7.9248;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {424db90c-191f-42dc-891f-3050966dcf63}, !- Handle
+  MidFloor_Plenum_Floor_4,                !- Name
+  Floor,                                  !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {7b5df7a4-7bf7-4b0e-9c4c-233b5f3bc4d7}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {65ca1e41-d751-4fc6-8e81-bb84b0585e6f}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 33.2738, 6.7056,                     !- X,Y,Z Vertex 1 {m}
+  4.5732, 28.7006, 6.7056,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 6.7056,                 !- X,Y,Z Vertex 3 {m}
+  0, 0, 6.7056;                           !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {369f0950-01d9-449e-a1ba-5822eab20653}, !- Handle
+  Perimeter_bot_ZN_4_Floor,               !- Name
+  Floor,                                  !- Surface Type
+  {4f011101-a6b7-4cde-98e5-2d67029d02d0}, !- Construction Name
+  {27fdb3c4-855f-48df-983a-24f85fe57204}, !- Space Name
+  Ground,                                 !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 33.2738, 0,                          !- X,Y,Z Vertex 1 {m}
+  4.5732, 28.7006, 0,                     !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 0,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 0;                                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {d1049dc7-583a-40e5-a50b-0cc08464a51e}, !- Handle
+  Perimeter_mid_ZN_4_Wall_East,           !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {fd517fa4-3c26-440a-aa97-3ace8c1c83b8}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {1da73790-e597-41f1-864c-62278390b7b7}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  4.5732, 4.5732, 6.7056,                 !- X,Y,Z Vertex 1 {m}
+  4.5732, 4.5732, 3.9624,                 !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 3.9624,                !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 6.7056;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {75054a96-9b2f-4c2a-b746-cbab05b4bd0b}, !- Handle
+  Perimeter_mid_Plenum_Wall_South,        !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {7b5df7a4-7bf7-4b0e-9c4c-233b5f3bc4d7}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 7.9248,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 6.7056,                           !- X,Y,Z Vertex 2 {m}
+  49.911, 0, 6.7056,                      !- X,Y,Z Vertex 3 {m}
+  49.911, 0, 7.9248;                      !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {7e4b1937-d8fc-4d9f-baea-4e0089caaa62}, !- Handle
+  Perimeter_top_ZN_2_Wall_East_Window,    !- Name
+  FixedWindow,                            !- Sub Surface Type
+  {1bc32cfb-af5e-403d-a471-8f5c989f4a11}, !- Construction Name
+  {0a632e83-54b1-4f21-a856-a0f274c5245f}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  1,                                      !- Multiplier
+  ,                                       !- Number of Vertices
+  49.911, 0, 10.2541,                     !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 8.9461,                      !- X,Y,Z Vertex 2 {m}
+  49.911, 33.2737, 8.9461,                !- X,Y,Z Vertex 3 {m}
+  49.911, 33.2737, 10.2541;               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {0a632e83-54b1-4f21-a856-a0f274c5245f}, !- Handle
+  Perimeter_top_ZN_2_Wall_East,           !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {eb32a2fb-5981-48a3-a152-e410cbe800cd}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 10.668,                      !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 7.9248,                      !- X,Y,Z Vertex 2 {m}
+  49.911, 33.2738, 7.9248,                !- X,Y,Z Vertex 3 {m}
+  49.911, 33.2738, 10.668;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {21521d19-6c0b-4aaf-bdef-7a25819baa97}, !- Handle
+  Perimeter_bot_ZN_2_Wall_West,           !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {a20d9a0e-f1f9-4c21-938a-707c85783069}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {f7f1b951-dcee-4fa9-9929-19b2dd55275a}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 2.7432,               !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 0,                    !- X,Y,Z Vertex 2 {m}
+  45.3375, 4.5732, 0,                     !- X,Y,Z Vertex 3 {m}
+  45.3375, 4.5732, 2.7432;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {4d637a49-840b-4869-b547-936d5bb25d9e}, !- Handle
+  Building_Roof,                          !- Name
+  RoofCeiling,                            !- Surface Type
+  {88490efb-9d32-4d49-9298-c38fc7d6b8c1}, !- Construction Name
+  {a6db022f-dfaa-45fa-9573-a2cb4bec5f66}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 11.8872,                     !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 11.8872,               !- X,Y,Z Vertex 2 {m}
+  0, 33.2738, 11.8872,                    !- X,Y,Z Vertex 3 {m}
+  0, 0, 11.8872;                          !- X,Y,Z Vertex 4 {m}
+
+OS:Construction,
+  {88490efb-9d32-4d49-9298-c38fc7d6b8c1}, !- Handle
+  IEAD Non-res Roof,                      !- Name
+  ,                                       !- Surface Rendering Name
+  {85619a51-745f-4ee1-8f9c-35834ddf8cf7}, !- Layer 1
+  {804292cc-ff21-4a9c-afeb-e2b37e35019b}, !- Layer 2
+  {31ad99cf-49b0-4d95-8bec-40e0c51c4e52}; !- Layer 3
+
+OS:Material,
+  {31ad99cf-49b0-4d95-8bec-40e0c51c4e52}, !- Handle
+  Metal Decking,                          !- Name
+  MediumSmooth,                           !- Roughness
+  0.0015,                                 !- Thickness {m}
+  45.006,                                 !- Conductivity {W/m-K}
+  7680,                                   !- Density {kg/m3}
+  418.4,                                  !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.3;                                    !- Visible Absorptance
+
+OS:Surface,
+  {e3ef4cff-a6fe-415a-b15d-68d73ba345ef}, !- Handle
+  FirstFloor_Plenum_Floor_3,              !- Name
+  Floor,                                  !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {af409fa8-d6d1-4cb3-ab07-78dd65cb9800}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {42f297ba-fea4-4e07-8b12-8ee449c53798}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 2.7432,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 2.7432,               !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 2.7432,                !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 2.7432;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {1bdb752d-ac24-4088-b04e-c816c7b182fe}, !- Handle
+  Perimeter_top_ZN_3_Wall_South,          !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {67aa5b71-cfb3-4a14-86b6-9f9ba9a407f8}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {b1b37198-dadf-4ba2-b5fe-54ebb498f337}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  4.5732, 28.7006, 10.668,                !- X,Y,Z Vertex 1 {m}
+  4.5732, 28.7006, 7.9248,                !- X,Y,Z Vertex 2 {m}
+  45.3375, 28.7006, 7.9248,               !- X,Y,Z Vertex 3 {m}
+  45.3375, 28.7006, 10.668;               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {f71b1ec4-102c-4010-840f-71d9fe8d68bd}, !- Handle
+  Perimeter_bot_ZN_4_Ceiling,             !- Name
+  RoofCeiling,                            !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {27fdb3c4-855f-48df-983a-24f85fe57204}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {f73e9304-b61a-4029-a354-099567b23887}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 2.7432,                           !- X,Y,Z Vertex 1 {m}
+  4.5732, 4.5732, 2.7432,                 !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 2.7432,                !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 2.7432;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {16f1f70c-ea26-43ef-834d-435d30364c4c}, !- Handle
+  Perimeter_mid_ZN_1_Floor,               !- Name
+  Floor,                                  !- Surface Type
+  {d24f1e89-cddb-4b47-9c0b-ae2ec431c1a6}, !- Construction Name
+  {bcf7adbf-62d7-4451-bd90-23e37f8bd918}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {08535030-e524-4f71-8ef9-c56906523e1a}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 3.9624,                !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 3.9624,                      !- X,Y,Z Vertex 2 {m}
+  0, 0, 3.9624,                           !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 3.9624;                 !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {7cbb4361-7d08-47d1-b03c-f838e46c7752}, !- Handle
+  Perimeter_bot_ZN_1_Wall_South_Window,   !- Name
+  FixedWindow,                            !- Sub Surface Type
+  {1bc32cfb-af5e-403d-a471-8f5c989f4a11}, !- Construction Name
+  {96a31391-8001-46f3-9a72-de2cd1602d0b}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  1,                                      !- Multiplier
+  ,                                       !- Number of Vertices
+  0, 0, 2.3293,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 1.0213,                           !- X,Y,Z Vertex 2 {m}
+  49.91, 0, 1.0213,                       !- X,Y,Z Vertex 3 {m}
+  49.91, 0, 2.3293;                       !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {96a31391-8001-46f3-9a72-de2cd1602d0b}, !- Handle
+  Perimeter_bot_ZN_1_Wall_South,          !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {dac06210-f4a7-4108-99da-b010224bcaf1}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 2.7432,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  49.911, 0, 0,                           !- X,Y,Z Vertex 3 {m}
+  49.911, 0, 2.7432;                      !- X,Y,Z Vertex 4 {m}
+
+OS:Material,
+  {32c0f473-fa9b-456f-a6e2-6c10931e6494}, !- Handle
+  1IN Stucco,                             !- Name
+  Smooth,                                 !- Roughness
+  0.0253,                                 !- Thickness {m}
+  0.6918,                                 !- Conductivity {W/m-K}
+  1858,                                   !- Density {kg/m3}
+  837,                                    !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.92,                                   !- Solar Absorptance
+  0.92;                                   !- Visible Absorptance
+
+OS:Surface,
+  {b49179e9-5cd4-470e-b116-d98f6092595b}, !- Handle
+  Perimeter_bot_Plenum_Wall_South,        !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {af409fa8-d6d1-4cb3-ab07-78dd65cb9800}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 3.9624,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 2.7432,                           !- X,Y,Z Vertex 2 {m}
+  49.911, 0, 2.7432,                      !- X,Y,Z Vertex 3 {m}
+  49.911, 0, 3.9624;                      !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {9dca61c1-611d-4e25-9674-71eb82516f4c}, !- Handle
+  Perimeter_mid_ZN_2_Wall_East,           !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {722a09e4-0646-4e5a-b78d-58b632bc69f7}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 6.7056,                      !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 3.9624,                      !- X,Y,Z Vertex 2 {m}
+  49.911, 33.2738, 3.9624,                !- X,Y,Z Vertex 3 {m}
+  49.911, 33.2738, 6.7056;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {7a1ce153-6a0f-4f11-bd9c-6f312bb90ffb}, !- Handle
+  FirstFloor_Plenum_Ceiling_5,            !- Name
+  RoofCeiling,                            !- Surface Type
+  {d2639f93-4cc4-4eee-90ec-1f31812be744}, !- Construction Name
+  {af409fa8-d6d1-4cb3-ab07-78dd65cb9800}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {830c7392-9ab2-4959-9004-29160e6a8d75}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 3.9624,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 3.9624,               !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 3.9624,                !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 3.9624;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {0e35c0cd-aeed-48e3-b2b5-fa592e21d9ff}, !- Handle
+  MidFloor_Plenum_Ceiling_5,              !- Name
+  RoofCeiling,                            !- Surface Type
+  {d2639f93-4cc4-4eee-90ec-1f31812be744}, !- Construction Name
+  {7b5df7a4-7bf7-4b0e-9c4c-233b5f3bc4d7}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {a8a74e7d-090b-4e22-b039-71eae59a3ba0}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 7.9248,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 7.9248,               !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 7.9248,                !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 7.9248;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {ea8dcbc4-54ad-42b7-9b79-23f2bca9c303}, !- Handle
+  Perimeter_bot_Plenum_Wall_East,         !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {af409fa8-d6d1-4cb3-ab07-78dd65cb9800}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 3.9624,                      !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 2.7432,                      !- X,Y,Z Vertex 2 {m}
+  49.911, 33.2738, 2.7432,                !- X,Y,Z Vertex 3 {m}
+  49.911, 33.2738, 3.9624;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {cf9c8df3-e6c1-47f4-91a8-b20dcc9d2508}, !- Handle
+  Core_top_ZN_5_Wall_East,                !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {b422ea64-bad8-4f36-9616-c0c97070580c}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {1e08d663-4124-4ab7-b91e-9601eb81a428}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 10.668,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 7.9248,                !- X,Y,Z Vertex 2 {m}
+  45.3375, 28.7006, 7.9248,               !- X,Y,Z Vertex 3 {m}
+  45.3375, 28.7006, 10.668;               !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {44b05f78-3311-4ebf-8494-242b24b5d38f}, !- Handle
+  Perimeter_top_ZN_3_Wall_North_Window,   !- Name
+  FixedWindow,                            !- Sub Surface Type
+  {1bc32cfb-af5e-403d-a471-8f5c989f4a11}, !- Construction Name
+  {b90242e8-7039-45eb-a313-1beb1f893fcb}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  1,                                      !- Multiplier
+  ,                                       !- Number of Vertices
+  49.91, 33.2738, 10.2541,                !- X,Y,Z Vertex 1 {m}
+  49.91, 33.2738, 8.9461,                 !- X,Y,Z Vertex 2 {m}
+  0, 33.2738, 8.9461,                     !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 10.2541;                    !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {c58d6c74-2e5e-493d-b071-3d4a79718031}, !- Handle
+  MidFloor_Plenum_Ceiling_1,              !- Name
+  RoofCeiling,                            !- Surface Type
+  {d2639f93-4cc4-4eee-90ec-1f31812be744}, !- Construction Name
+  {7b5df7a4-7bf7-4b0e-9c4c-233b5f3bc4d7}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {1eb4308a-1c72-4ba1-8306-05c13e0baa91}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 7.9248,                      !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 7.9248,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 7.9248,                 !- X,Y,Z Vertex 3 {m}
+  0, 0, 7.9248;                           !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {2c37d6ed-ad22-4603-9357-7cc89b13d8a7}, !- Handle
+  Perimeter_top_Plenum_Wall_South,        !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {a6db022f-dfaa-45fa-9573-a2cb4bec5f66}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 11.8872,                          !- X,Y,Z Vertex 1 {m}
+  0, 0, 10.668,                           !- X,Y,Z Vertex 2 {m}
+  49.911, 0, 10.668,                      !- X,Y,Z Vertex 3 {m}
+  49.911, 0, 11.8872;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {8660326f-4758-4779-bab8-6ba75b8988f6}, !- Handle
+  Perimeter_top_ZN_4_Floor,               !- Name
+  Floor,                                  !- Surface Type
+  {d24f1e89-cddb-4b47-9c0b-ae2ec431c1a6}, !- Construction Name
+  {a47d34ed-7efc-47ea-bdaa-671d58f47564}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {57a170ff-8fbc-4d8e-bde1-b1f6a3991342}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 33.2738, 7.9248,                     !- X,Y,Z Vertex 1 {m}
+  4.5732, 28.7006, 7.9248,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 7.9248,                 !- X,Y,Z Vertex 3 {m}
+  0, 0, 7.9248;                           !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {26934833-d66f-46f8-b52e-e1b2431e06a0}, !- Handle
+  FirstFloor_Plenum_Floor_1,              !- Name
+  Floor,                                  !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {af409fa8-d6d1-4cb3-ab07-78dd65cb9800}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {bce01acf-8760-4c6f-b164-976d317f0b5e}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 2.7432,                !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 2.7432,                      !- X,Y,Z Vertex 2 {m}
+  0, 0, 2.7432,                           !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 2.7432;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {a8a74e7d-090b-4e22-b039-71eae59a3ba0}, !- Handle
+  Core_top_ZN_5_Floor,                    !- Name
+  Floor,                                  !- Surface Type
+  {d24f1e89-cddb-4b47-9c0b-ae2ec431c1a6}, !- Construction Name
+  {b422ea64-bad8-4f36-9616-c0c97070580c}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {0e35c0cd-aeed-48e3-b2b5-fa592e21d9ff}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 7.9248,               !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 7.9248,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 7.9248,                 !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 7.9248;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {88ceb210-970e-406c-975f-93c3b142b72b}, !- Handle
+  Perimeter_mid_ZN_1_Wall_North,          !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {bcf7adbf-62d7-4451-bd90-23e37f8bd918}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {716e8614-0037-4a42-99c3-634d9645608b}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 6.7056,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 3.9624,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 3.9624,                 !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 6.7056;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {a4afde50-40b0-453c-9817-a20848908c98}, !- Handle
+  Perimeter_mid_ZN_1_Wall_East,           !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {bcf7adbf-62d7-4451-bd90-23e37f8bd918}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {b45a34b1-1722-4213-8b33-ab24a1a8c687}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 6.7056,                      !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 3.9624,                      !- X,Y,Z Vertex 2 {m}
+  45.3375, 4.5732, 3.9624,                !- X,Y,Z Vertex 3 {m}
+  45.3375, 4.5732, 6.7056;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {956e619f-d76c-4b73-9fe3-44bbe0d012ad}, !- Handle
+  Perimeter_mid_ZN_2_Ceiling,             !- Name
+  RoofCeiling,                            !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {722a09e4-0646-4e5a-b78d-58b632bc69f7}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {4278eb4f-8536-4876-8396-2197d716dd8c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 6.7056,                      !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 6.7056,                !- X,Y,Z Vertex 2 {m}
+  45.3375, 28.7006, 6.7056,               !- X,Y,Z Vertex 3 {m}
+  45.3375, 4.5732, 6.7056;                !- X,Y,Z Vertex 4 {m}
+
+OS:SizingPeriod:DesignDay,
+  {e4145645-02b9-4a4f-b15e-3fac5660f29b}, !- Handle
+  CHICAGO Ann Htg 99.6% Condns DB,        !- Name
+  -20.6,                                  !- Maximum Dry-Bulb Temperature {C}
+  0,                                      !- Daily Dry-Bulb Temperature Range {deltaC}
+  -20.6,                                  !- Humidity Indicating Conditions at Maximum Dry-Bulb {BasedOnField A3}
+  99063,                                  !- Barometric Pressure {Pa}
+  4.9,                                    !- Wind Speed {m/s}
+  270,                                    !- Wind Direction {deg}
+  0,                                      !- Sky Clearness
+  0,                                      !- Rain Indicator
+  0,                                      !- Snow Indicator
+  21,                                     !- Day of Month
+  1,                                      !- Month
+  WinterDesignDay,                        !- Day Type
+  0,                                      !- Daylight Saving Time Indicator
+  Wetbulb,                                !- Humidity Indicating Type
+  ,                                       !- Humidity Indicating Day Schedule Name
+  ,                                       !- Dry-Bulb Temperature Range Modifier Type
+  ,                                       !- Dry-Bulb Temperature Range Modifier Schedule Name
+  ASHRAEClearSky;                         !- Solar Model Indicator
+
+OS:Construction,
+  {a531cffd-e268-40b8-acbc-701264f49534}, !- Handle
+  AIR-WALL,                               !- Name
+  ,                                       !- Surface Rendering Name
+  {9f09ba8b-23c0-4911-8c51-2077115d9238}; !- Layer 1
+
+OS:Surface,
+  {1e92221a-6a93-42e3-a60c-bd2b270e4be6}, !- Handle
+  Perimeter_mid_ZN_2_Wall_West,           !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {722a09e4-0646-4e5a-b78d-58b632bc69f7}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {a49f86c6-0d96-48c2-814b-b265e7fe2389}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 6.7056,               !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 3.9624,               !- X,Y,Z Vertex 2 {m}
+  45.3375, 4.5732, 3.9624,                !- X,Y,Z Vertex 3 {m}
+  45.3375, 4.5732, 6.7056;                !- X,Y,Z Vertex 4 {m}
+
+OS:HeatBalanceAlgorithm,
+  {fe715ac5-1bf3-4a57-9824-bb1cce42f1d3}, !- Handle
+  ConductionTransferFunction,             !- Algorithm
+  200;                                    !- Surface Temperature Upper Limit {F}
+
+OS:Surface,
+  {6c8b7465-4702-4e73-8e68-4218cd0aaf80}, !- Handle
+  Perimeter_top_ZN_3_Ceiling,             !- Name
+  RoofCeiling,                            !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {67aa5b71-cfb3-4a14-86b6-9f9ba9a407f8}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {778f8aa0-9aa4-4818-87a4-34cf41f4c45f}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 10.668,               !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 10.668,                !- X,Y,Z Vertex 2 {m}
+  0, 33.2738, 10.668,                     !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 10.668;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {a2db1797-7b2b-4a2e-80fd-215448f8c403}, !- Handle
+  Perimeter_top_ZN_2_Ceiling,             !- Name
+  RoofCeiling,                            !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {eb32a2fb-5981-48a3-a152-e410cbe800cd}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {730512f5-ffc8-484e-bb18-6d69b42f11cb}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 10.668,                      !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 10.668,                !- X,Y,Z Vertex 2 {m}
+  45.3375, 28.7006, 10.668,               !- X,Y,Z Vertex 3 {m}
+  45.3375, 4.5732, 10.668;                !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {92b92f96-5203-40ca-b645-14273b576df1}, !- Handle
+  Perimeter_top_ZN_1_Wall_South_Window,   !- Name
+  FixedWindow,                            !- Sub Surface Type
+  {1bc32cfb-af5e-403d-a471-8f5c989f4a11}, !- Construction Name
+  {fe74b4ea-125a-47b6-85bc-df2503f70382}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  1,                                      !- Multiplier
+  ,                                       !- Number of Vertices
+  0, 0, 10.2541,                          !- X,Y,Z Vertex 1 {m}
+  0, 0, 8.9461,                           !- X,Y,Z Vertex 2 {m}
+  49.91, 0, 8.9461,                       !- X,Y,Z Vertex 3 {m}
+  49.91, 0, 10.2541;                      !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {fe74b4ea-125a-47b6-85bc-df2503f70382}, !- Handle
+  Perimeter_top_ZN_1_Wall_South,          !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {4c8e12a9-92e8-4ff5-b054-f47863b51cf4}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 10.668,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 7.9248,                           !- X,Y,Z Vertex 2 {m}
+  49.911, 0, 7.9248,                      !- X,Y,Z Vertex 3 {m}
+  49.911, 0, 10.668;                      !- X,Y,Z Vertex 4 {m}
+
+OS:ThermalZone,
+  {10ec4762-e63d-468e-8920-3210a7de1b8e}, !- Handle
+  Perimeter_top_ZN_1 Thermal Zone,        !- Name
+  1,                                      !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {95788fe8-5ea1-47c7-b10a-62d079916859}, !- Zone Air Inlet Port List
+  {630ba5e7-f536-4325-a442-094dfd1a9040}, !- Zone Air Exhaust Port List
+  {ef52e319-cb16-46d7-bcee-4e1844096863}, !- Zone Air Node Name
+  ,                                       !- Zone Return Air Node Name
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  ,                                       !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {8bc36fc4-de98-4ebf-9c21-ef2ad4e0ecbc}, !- Handle
+  {1fd09114-2d32-4662-be4e-5fe7ef99d82b}, !- Name
+  {ef52e319-cb16-46d7-bcee-4e1844096863}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {ef52e319-cb16-46d7-bcee-4e1844096863}, !- Handle
+  {a164423f-6700-409e-8867-05dbc4972732}, !- Name
+  {10ec4762-e63d-468e-8920-3210a7de1b8e}, !- Source Object
+  11,                                     !- Outlet Port
+  {8bc36fc4-de98-4ebf-9c21-ef2ad4e0ecbc}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {95788fe8-5ea1-47c7-b10a-62d079916859}, !- Handle
+  {3fcbb31c-6744-4482-bd75-219c79634d77}, !- Name
+  {10ec4762-e63d-468e-8920-3210a7de1b8e}; !- HVAC Component
+
+OS:PortList,
+  {630ba5e7-f536-4325-a442-094dfd1a9040}, !- Handle
+  {00a524b7-2408-412d-86de-32981ee85ce6}, !- Name
+  {10ec4762-e63d-468e-8920-3210a7de1b8e}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {a71fc79f-7261-4888-aff6-a010db44eca8}, !- Handle
+  {10ec4762-e63d-468e-8920-3210a7de1b8e}, !- Zone or ZoneList Name
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+
+OS:ZoneHVAC:EquipmentList,
+  {998f1318-b252-4794-8b83-10a0fbe20725}, !- Handle
+  {88bde209-0c29-4f84-872c-cccb06d6485f}, !- Name
+  {10ec4762-e63d-468e-8920-3210a7de1b8e}; !- Thermal Zone
+
+OS:Space,
+  {4c8e12a9-92e8-4ff5-b054-f47863b51cf4}, !- Handle
+  Perimeter_top_ZN_1,                     !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  0,                                      !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  ,                                       !- Building Story Name
+  {10ec4762-e63d-468e-8920-3210a7de1b8e}, !- Thermal Zone Name
+  Yes;                                    !- Part of Total Floor Area
+
+OS:Surface,
+  {578caafc-0a89-48e9-a1fb-c8ed716258b4}, !- Handle
+  Core_mid_ZN_5_Wall_North,               !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {493f6d08-7166-456d-ac62-2aa6ae1e0923}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {83cacdc3-8dcd-43e2-98a9-4353e0e2a3cf}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 6.7056,               !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 3.9624,               !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 3.9624,                !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 6.7056;                !- X,Y,Z Vertex 4 {m}
+
+OS:ThermalZone,
+  {cb8acd6a-4635-41ea-b73d-703acf53443f}, !- Handle
+  Core_mid Thermal Zone,                  !- Name
+  1,                                      !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {51cdea07-314f-4fdd-8049-96be2e5339c5}, !- Zone Air Inlet Port List
+  {4416e3f2-bd9b-4b14-8746-2a54cb31b590}, !- Zone Air Exhaust Port List
+  {e53a869f-657d-441c-85b2-61ebe0df1aa6}, !- Zone Air Node Name
+  ,                                       !- Zone Return Air Node Name
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  ,                                       !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {10850634-f244-4be1-b03d-a650c910294a}, !- Handle
+  {bfacc2e3-7a5a-4d4f-bc6a-ee1e45e80a79}, !- Name
+  {e53a869f-657d-441c-85b2-61ebe0df1aa6}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {e53a869f-657d-441c-85b2-61ebe0df1aa6}, !- Handle
+  {d0eaf297-800a-46eb-85a4-91bc2b035261}, !- Name
+  {cb8acd6a-4635-41ea-b73d-703acf53443f}, !- Source Object
+  11,                                     !- Outlet Port
+  {10850634-f244-4be1-b03d-a650c910294a}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {51cdea07-314f-4fdd-8049-96be2e5339c5}, !- Handle
+  {d293647e-d0da-41ac-92f4-5bf4e95ffac4}, !- Name
+  {cb8acd6a-4635-41ea-b73d-703acf53443f}; !- HVAC Component
+
+OS:PortList,
+  {4416e3f2-bd9b-4b14-8746-2a54cb31b590}, !- Handle
+  {12cd9f6b-c584-41cd-be00-f217cefcf6c4}, !- Name
+  {cb8acd6a-4635-41ea-b73d-703acf53443f}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {6c3e263c-fbaf-46fd-bcde-f57a3b170595}, !- Handle
+  {cb8acd6a-4635-41ea-b73d-703acf53443f}, !- Zone or ZoneList Name
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+
+OS:ZoneHVAC:EquipmentList,
+  {617b3cfd-a157-4f45-938a-132f64107431}, !- Handle
+  {62b0b5e4-7cae-497e-877b-2193c3cd2455}, !- Name
+  {cb8acd6a-4635-41ea-b73d-703acf53443f}; !- Thermal Zone
+
+OS:Space,
+  {493f6d08-7166-456d-ac62-2aa6ae1e0923}, !- Handle
+  Core_mid,                               !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  0,                                      !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  ,                                       !- Building Story Name
+  {cb8acd6a-4635-41ea-b73d-703acf53443f}, !- Thermal Zone Name
+  Yes;                                    !- Part of Total Floor Area
+
+OS:SubSurface,
+  {f68d63e6-5827-49c5-93b0-2a29404ad220}, !- Handle
+  Perimeter_mid_ZN_2_Wall_East_Window,    !- Name
+  FixedWindow,                            !- Sub Surface Type
+  {1bc32cfb-af5e-403d-a471-8f5c989f4a11}, !- Construction Name
+  {9dca61c1-611d-4e25-9674-71eb82516f4c}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  1,                                      !- Multiplier
+  ,                                       !- Number of Vertices
+  49.911, 0, 6.2917,                      !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 4.9837,                      !- X,Y,Z Vertex 2 {m}
+  49.911, 33.2737, 4.9837,                !- X,Y,Z Vertex 3 {m}
+  49.911, 33.2737, 6.2917;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {4d501b81-344c-4ade-b8c3-2032b7b438a6}, !- Handle
+  Perimeter_mid_ZN_2_Floor,               !- Name
+  Floor,                                  !- Surface Type
+  {d24f1e89-cddb-4b47-9c0b-ae2ec431c1a6}, !- Construction Name
+  {722a09e4-0646-4e5a-b78d-58b632bc69f7}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {475104a5-3781-41de-b09f-706fd82184d0}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 3.9624,                !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 3.9624,                      !- X,Y,Z Vertex 2 {m}
+  45.3375, 4.5732, 3.9624,                !- X,Y,Z Vertex 3 {m}
+  45.3375, 28.7006, 3.9624;               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {2a5440cd-ea85-4103-b898-e494c25a3868}, !- Handle
+  Perimeter_top_ZN_1_Wall_West,           !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {4c8e12a9-92e8-4ff5-b054-f47863b51cf4}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {61d12225-bce5-4b99-80ed-34e17a0a5b59}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  4.5732, 4.5732, 10.668,                 !- X,Y,Z Vertex 1 {m}
+  4.5732, 4.5732, 7.9248,                 !- X,Y,Z Vertex 2 {m}
+  0, 0, 7.9248,                           !- X,Y,Z Vertex 3 {m}
+  0, 0, 10.668;                           !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {8efef24a-80d8-4f06-ab27-e51f2a68056b}, !- Handle
+  Perimeter_bot_ZN_4_Wall_West,           !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {27fdb3c4-855f-48df-983a-24f85fe57204}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 33.2738, 2.7432,                     !- X,Y,Z Vertex 1 {m}
+  0, 33.2738, 0,                          !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 2.7432;                           !- X,Y,Z Vertex 4 {m}
+
+OS:ConvergenceLimits,
+  {ea7161c9-2055-499f-ae58-3521b531b167}, !- Handle
+  2,                                      !- Minimum System Timestep {minutes}
+  25;                                     !- Maximum HVAC Iterations
+
+OS:Surface,
+  {b1b37198-dadf-4ba2-b5fe-54ebb498f337}, !- Handle
+  Core_top_ZN_5_Wall_North,               !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {b422ea64-bad8-4f36-9616-c0c97070580c}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {1bdb752d-ac24-4088-b04e-c816c7b182fe}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 10.668,               !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 7.9248,               !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 7.9248,                !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 10.668;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {4f0eee25-7cf0-4c5a-8f95-6e0c5d25448c}, !- Handle
+  Core_bot_ZN_5_Wall_West,                !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {0301d7f6-33a7-4967-9d2b-ab9b1cfbe5aa}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {bf1bdda1-7ff2-4daa-aa1f-4437429b5ee4}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  4.5732, 28.7006, 2.7432,                !- X,Y,Z Vertex 1 {m}
+  4.5732, 28.7006, 0,                     !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 0,                      !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 2.7432;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {732613f2-0899-40fc-bd03-275c5534784e}, !- Handle
+  Perimeter_bot_ZN_2_Wall_South,          !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {a20d9a0e-f1f9-4c21-938a-707c85783069}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {c21f9bf2-f8db-472a-a7bb-4e278c1501a0}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 2.7432,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 0,                     !- X,Y,Z Vertex 2 {m}
+  49.911, 0, 0,                           !- X,Y,Z Vertex 3 {m}
+  49.911, 0, 2.7432;                      !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {2a6df47f-9a0f-4c06-aeee-edfa69f5149b}, !- Handle
+  Perimeter_top_ZN_1_Ceiling,             !- Name
+  RoofCeiling,                            !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {4c8e12a9-92e8-4ff5-b054-f47863b51cf4}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {c0de71ed-6430-4976-bfb7-bb9409c60843}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 10.668,                      !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 10.668,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 10.668,                 !- X,Y,Z Vertex 3 {m}
+  0, 0, 10.668;                           !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {e074cec9-2ef2-4fca-bd0a-4fa8389dcc3d}, !- Handle
+  Perimeter_mid_ZN_1_Wall_South_Window,   !- Name
+  FixedWindow,                            !- Sub Surface Type
+  {1bc32cfb-af5e-403d-a471-8f5c989f4a11}, !- Construction Name
+  {fcb9c303-60b7-4799-9da3-3f3fb86942b1}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  1,                                      !- Multiplier
+  ,                                       !- Number of Vertices
+  0, 0, 6.2917,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 4.9837,                           !- X,Y,Z Vertex 2 {m}
+  49.91, 0, 4.9837,                       !- X,Y,Z Vertex 3 {m}
+  49.91, 0, 6.2917;                       !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {fcb9c303-60b7-4799-9da3-3f3fb86942b1}, !- Handle
+  Perimeter_mid_ZN_1_Wall_South,          !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {bcf7adbf-62d7-4451-bd90-23e37f8bd918}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 6.7056,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.9624,                           !- X,Y,Z Vertex 2 {m}
+  49.911, 0, 3.9624,                      !- X,Y,Z Vertex 3 {m}
+  49.911, 0, 6.7056;                      !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {a49f86c6-0d96-48c2-814b-b265e7fe2389}, !- Handle
+  Core_mid_ZN_5_Wall_East,                !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {493f6d08-7166-456d-ac62-2aa6ae1e0923}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {1e92221a-6a93-42e3-a60c-bd2b270e4be6}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 6.7056,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 3.9624,                !- X,Y,Z Vertex 2 {m}
+  45.3375, 28.7006, 3.9624,               !- X,Y,Z Vertex 3 {m}
+  45.3375, 28.7006, 6.7056;               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {850637cc-a8a1-4eba-b885-16d5d92d7986}, !- Handle
+  Perimeter_bot_ZN_1_Wall_North,          !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {dac06210-f4a7-4108-99da-b010224bcaf1}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {6fda72e7-e9a3-456f-99d8-861fd64ce491}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 2.7432,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 0,                     !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 0,                      !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 2.7432;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {507f3231-1a82-4997-afd8-1cb4825c2dfa}, !- Handle
+  Perimeter_mid_ZN_3_Wall_East,           !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {ec891589-6c66-4218-912e-610c05f9fca6}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {366cd017-9214-406c-bf3a-de5e4e5f5140}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 6.7056,               !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 3.9624,               !- X,Y,Z Vertex 2 {m}
+  49.911, 33.2738, 3.9624,                !- X,Y,Z Vertex 3 {m}
+  49.911, 33.2738, 6.7056;                !- X,Y,Z Vertex 4 {m}
+
+OS:ThermalZone,
+  {ffb0aa77-26c7-4773-ba2c-02a716294d09}, !- Handle
+  Perimeter_mid_ZN_3 Thermal Zone,        !- Name
+  1,                                      !- Multiplier
+  ,                                       !- Ceiling Height {m}
+  ,                                       !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {42b66e8b-df24-4566-b7e1-0ae68c2740ce}, !- Zone Air Inlet Port List
+  {213eb1cc-3c3f-4b0d-87d4-2e4c1e54a482}, !- Zone Air Exhaust Port List
+  {8c9efdf8-3b32-42c5-b1ad-e36c8733239e}, !- Zone Air Node Name
+  ,                                       !- Zone Return Air Node Name
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  ,                                       !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {3b98d838-b6f2-401e-8cb1-5751e119506e}, !- Handle
+  {c2e84e5a-c2d8-4a1b-91d0-407c97cbfe14}, !- Name
+  {8c9efdf8-3b32-42c5-b1ad-e36c8733239e}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {8c9efdf8-3b32-42c5-b1ad-e36c8733239e}, !- Handle
+  {f3ca1d55-5588-4c98-a52d-9f9730f17b86}, !- Name
+  {ffb0aa77-26c7-4773-ba2c-02a716294d09}, !- Source Object
+  11,                                     !- Outlet Port
+  {3b98d838-b6f2-401e-8cb1-5751e119506e}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {42b66e8b-df24-4566-b7e1-0ae68c2740ce}, !- Handle
+  {ee2c5a10-093d-4bbc-883d-d918347cbdcc}, !- Name
+  {ffb0aa77-26c7-4773-ba2c-02a716294d09}; !- HVAC Component
+
+OS:PortList,
+  {213eb1cc-3c3f-4b0d-87d4-2e4c1e54a482}, !- Handle
+  {8f0a58c2-4752-4eec-93af-034cce8b4e04}, !- Name
+  {ffb0aa77-26c7-4773-ba2c-02a716294d09}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {f9a0dd93-aaed-426d-8133-a84ca1e76d7a}, !- Handle
+  {ffb0aa77-26c7-4773-ba2c-02a716294d09}, !- Zone or ZoneList Name
+  14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
+  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+
+OS:ZoneHVAC:EquipmentList,
+  {3ffd4543-ce45-4c01-a438-1f0c80296855}, !- Handle
+  {0314c9fa-2703-4fc6-a541-10478ca7f69c}, !- Name
+  {ffb0aa77-26c7-4773-ba2c-02a716294d09}; !- Thermal Zone
+
+OS:Space,
+  {ec891589-6c66-4218-912e-610c05f9fca6}, !- Handle
+  Perimeter_mid_ZN_3,                     !- Name
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  0,                                      !- Direction of Relative North {deg}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
+  ,                                       !- Building Story Name
+  {ffb0aa77-26c7-4773-ba2c-02a716294d09}, !- Thermal Zone Name
+  Yes;                                    !- Part of Total Floor Area
+
+OS:Surface,
+  {42f297ba-fea4-4e07-8b12-8ee449c53798}, !- Handle
+  Perimeter_bot_ZN_3_Ceililng,            !- Name
+  RoofCeiling,                            !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {c7f6e37f-54b9-4246-b00b-8ba5739f031d}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {e3ef4cff-a6fe-415a-b15d-68d73ba345ef}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 2.7432,               !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 2.7432,                !- X,Y,Z Vertex 2 {m}
+  0, 33.2738, 2.7432,                     !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 2.7432;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {c1930421-c933-405a-bbdf-a9d912313c7d}, !- Handle
+  FirstFloor_Plenum_Floor_5,              !- Name
+  Floor,                                  !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {af409fa8-d6d1-4cb3-ab07-78dd65cb9800}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {04828872-5aee-42c2-ac8c-4d56fde3586c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 2.7432,               !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 2.7432,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 2.7432,                 !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 2.7432;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {dc8e2d51-8321-4958-909a-e83420f7a54a}, !- Handle
+  Perimeter_bot_Plenum_Wall_North,        !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {af409fa8-d6d1-4cb3-ab07-78dd65cb9800}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 3.9624,                !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 2.7432,                !- X,Y,Z Vertex 2 {m}
+  0, 33.2738, 2.7432,                     !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 3.9624;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Material,
+  {5b78b74f-ccdf-4603-a70f-c803de70f7a9}, !- Handle
+  8IN CONCRETE HW,                        !- Name
+  Rough,                                  !- Roughness
+  0.2032,                                 !- Thickness {m}
+  1.311,                                  !- Conductivity {W/m-K}
+  2240,                                   !- Density {kg/m3}
+  836.8,                                  !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:Surface,
+  {8274b4df-f5ef-4ea6-a7b3-da9f4a1d7ab6}, !- Handle
+  Perimeter_bot_ZN_2_Floor,               !- Name
+  Floor,                                  !- Surface Type
+  {4f011101-a6b7-4cde-98e5-2d67029d02d0}, !- Construction Name
+  {a20d9a0e-f1f9-4c21-938a-707c85783069}, !- Space Name
+  Ground,                                 !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 0,                     !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 0,                           !- X,Y,Z Vertex 2 {m}
+  45.3375, 4.5732, 0,                     !- X,Y,Z Vertex 3 {m}
+  45.3375, 28.7006, 0;                    !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {88c74cf5-8639-441e-8899-481ea739e404}, !- Handle
+  Perimeter_top_ZN_1_Wall_North,          !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {4c8e12a9-92e8-4ff5-b054-f47863b51cf4}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {2112c288-4f79-47d5-a164-06bbbec3d999}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 10.668,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 7.9248,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 7.9248,                 !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 10.668;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {66638ba4-8d38-402a-a471-5928e57298da}, !- Handle
+  Perimeter_top_ZN_3_Wall_East,           !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {67aa5b71-cfb3-4a14-86b6-9f9ba9a407f8}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {6fff4b0b-8156-41a5-ae7c-a4311d964625}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 10.668,               !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 7.9248,               !- X,Y,Z Vertex 2 {m}
+  49.911, 33.2738, 7.9248,                !- X,Y,Z Vertex 3 {m}
+  49.911, 33.2738, 10.668;                !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {6e168560-1113-4c97-aba7-88e2a559b10b}, !- Handle
+  Perimeter_bot_ZN_3_Wall_North_Window,   !- Name
+  FixedWindow,                            !- Sub Surface Type
+  {1bc32cfb-af5e-403d-a471-8f5c989f4a11}, !- Construction Name
+  {c4c69e54-2157-4950-8388-5e464612dd2b}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  1,                                      !- Multiplier
+  ,                                       !- Number of Vertices
+  49.91, 33.2738, 2.3293,                 !- X,Y,Z Vertex 1 {m}
+  49.91, 33.2738, 1.0213,                 !- X,Y,Z Vertex 2 {m}
+  0, 33.2738, 1.0213,                     !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 2.3293;                     !- X,Y,Z Vertex 4 {m}
+
+OS:SizingPeriod:DesignDay,
+  {e0c472fa-7b49-4bbe-aa75-fc65522b69ea}, !- Handle
+  CHICAGO Ann Clg .4% Condns WB=>MDB,     !- Name
+  31.2,                                   !- Maximum Dry-Bulb Temperature {C}
+  10.7,                                   !- Daily Dry-Bulb Temperature Range {deltaC}
+  25.5,                                   !- Humidity Indicating Conditions at Maximum Dry-Bulb {BasedOnField A3}
+  99063,                                  !- Barometric Pressure {Pa}
+  5.3,                                    !- Wind Speed {m/s}
+  230,                                    !- Wind Direction {deg}
+  1,                                      !- Sky Clearness
+  0,                                      !- Rain Indicator
+  0,                                      !- Snow Indicator
+  21,                                     !- Day of Month
+  7,                                      !- Month
+  SummerDesignDay,                        !- Day Type
+  0,                                      !- Daylight Saving Time Indicator
+  Wetbulb,                                !- Humidity Indicating Type
+  ,                                       !- Humidity Indicating Day Schedule Name
+  ,                                       !- Dry-Bulb Temperature Range Modifier Type
+  ,                                       !- Dry-Bulb Temperature Range Modifier Schedule Name
+  ASHRAEClearSky;                         !- Solar Model Indicator
+
+OS:Surface,
+  {0723f01d-e17b-495b-bd34-61016872d5f7}, !- Handle
+  Perimeter_bot_ZN_2_Wall_North,          !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {a20d9a0e-f1f9-4c21-938a-707c85783069}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {d3b3e593-ab36-48cf-9b7a-c710daed9530}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 2.7432,                !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 0,                     !- X,Y,Z Vertex 2 {m}
+  45.3375, 28.7006, 0,                    !- X,Y,Z Vertex 3 {m}
+  45.3375, 28.7006, 2.7432;               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {fe7ad4a5-554d-4268-8179-77f7780ee204}, !- Handle
+  MidFloor_Plenum_Ceiling_2,              !- Name
+  RoofCeiling,                            !- Surface Type
+  {d2639f93-4cc4-4eee-90ec-1f31812be744}, !- Construction Name
+  {7b5df7a4-7bf7-4b0e-9c4c-233b5f3bc4d7}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {287e05fd-63e9-4119-9fd8-48bb2ee44440}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 7.9248,                      !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 7.9248,                !- X,Y,Z Vertex 2 {m}
+  45.3375, 28.7006, 7.9248,               !- X,Y,Z Vertex 3 {m}
+  45.3375, 4.5732, 7.9248;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {730512f5-ffc8-484e-bb18-6d69b42f11cb}, !- Handle
+  TopFloor_Plenum_Floor_2,                !- Name
+  Floor,                                  !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {a6db022f-dfaa-45fa-9573-a2cb4bec5f66}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {a2db1797-7b2b-4a2e-80fd-215448f8c403}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 10.668,                !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 10.668,                      !- X,Y,Z Vertex 2 {m}
+  45.3375, 4.5732, 10.668,                !- X,Y,Z Vertex 3 {m}
+  45.3375, 28.7006, 10.668;               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {1da73790-e597-41f1-864c-62278390b7b7}, !- Handle
+  Core_mid_ZN_5_Wall_West,                !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {493f6d08-7166-456d-ac62-2aa6ae1e0923}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {d1049dc7-583a-40e5-a50b-0cc08464a51e}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  4.5732, 28.7006, 6.7056,                !- X,Y,Z Vertex 1 {m}
+  4.5732, 28.7006, 3.9624,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 3.9624,                 !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 6.7056;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {3a20baa7-ba7c-49f9-9b77-cab260cad18d}, !- Handle
+  Perimeter_bot_ZN_3_Wall_South,          !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {c7f6e37f-54b9-4246-b00b-8ba5739f031d}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {af9a19d0-4115-4c85-a9f9-266ec4973890}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  4.5732, 28.7006, 2.7432,                !- X,Y,Z Vertex 1 {m}
+  4.5732, 28.7006, 0,                     !- X,Y,Z Vertex 2 {m}
+  45.3375, 28.7006, 0,                    !- X,Y,Z Vertex 3 {m}
+  45.3375, 28.7006, 2.7432;               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {83cacdc3-8dcd-43e2-98a9-4353e0e2a3cf}, !- Handle
+  Perimeter_mid_ZN_3_Wall_South,          !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {ec891589-6c66-4218-912e-610c05f9fca6}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {578caafc-0a89-48e9-a1fb-c8ed716258b4}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  4.5732, 28.7006, 6.7056,                !- X,Y,Z Vertex 1 {m}
+  4.5732, 28.7006, 3.9624,                !- X,Y,Z Vertex 2 {m}
+  45.3375, 28.7006, 3.9624,               !- X,Y,Z Vertex 3 {m}
+  45.3375, 28.7006, 6.7056;               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {2c105491-2cb6-417d-8943-ad87b1c2fc11}, !- Handle
+  Perimeter_top_ZN_4_Ceiling,             !- Name
+  RoofCeiling,                            !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {a47d34ed-7efc-47ea-bdaa-671d58f47564}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {914d9885-c299-4083-a7f6-1500ca96db2f}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 10.668,                           !- X,Y,Z Vertex 1 {m}
+  4.5732, 4.5732, 10.668,                 !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 10.668,                !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 10.668;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {97040a33-8c54-4e3a-92db-805fd6eaad66}, !- Handle
+  Core_mid_ceiling,                       !- Name
+  RoofCeiling,                            !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {493f6d08-7166-456d-ac62-2aa6ae1e0923}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {a19a8ac6-9cd3-4882-b819-068c6ebdd97f}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 6.7056,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 6.7056,               !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 6.7056,                !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 6.7056;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {6fff4b0b-8156-41a5-ae7c-a4311d964625}, !- Handle
+  Perimeter_top_ZN_2_Wall_North,          !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {eb32a2fb-5981-48a3-a152-e410cbe800cd}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {66638ba4-8d38-402a-a471-5928e57298da}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 10.668,                !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 7.9248,                !- X,Y,Z Vertex 2 {m}
+  45.3375, 28.7006, 7.9248,               !- X,Y,Z Vertex 3 {m}
+  45.3375, 28.7006, 10.668;               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {5a783f68-56f1-4c37-b5ad-498e9a045418}, !- Handle
+  Perimeter_top_ZN_1_Wall_East,           !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {4c8e12a9-92e8-4ff5-b054-f47863b51cf4}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {87e0c255-21c8-4ad8-a88b-59d2b89d337b}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 10.668,                      !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 7.9248,                      !- X,Y,Z Vertex 2 {m}
+  45.3375, 4.5732, 7.9248,                !- X,Y,Z Vertex 3 {m}
+  45.3375, 4.5732, 10.668;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {c21f9bf2-f8db-472a-a7bb-4e278c1501a0}, !- Handle
+  Perimeter_bot_ZN_1_Wall_East,           !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {dac06210-f4a7-4108-99da-b010224bcaf1}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {732613f2-0899-40fc-bd03-275c5534784e}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 2.7432,                      !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 0,                           !- X,Y,Z Vertex 2 {m}
+  45.3375, 4.5732, 0,                     !- X,Y,Z Vertex 3 {m}
+  45.3375, 4.5732, 2.7432;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {72d07376-ee0f-4e41-b355-ef18b1e157b8}, !- Handle
+  Perimeter_bot_ZN_1_Wall_West,           !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {dac06210-f4a7-4108-99da-b010224bcaf1}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {f6f8401d-43b6-4c1b-b872-99194b5771e9}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  4.5732, 4.5732, 2.7432,                 !- X,Y,Z Vertex 1 {m}
+  4.5732, 4.5732, 0,                      !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 2.7432;                           !- X,Y,Z Vertex 4 {m}
+
+OS:Construction,
+  {b0df3c0e-af40-4927-88ef-9548682cb530}, !- Handle
+  InteriorFurnishings,                    !- Name
+  ,                                       !- Surface Rendering Name
+  {6aabe660-38b7-496e-9f6e-8938539c4fdf}; !- Layer 1
+
+OS:Material,
+  {6aabe660-38b7-496e-9f6e-8938539c4fdf}, !- Handle
+  Std Wood 6inch,                         !- Name
+  MediumSmooth,                           !- Roughness
+  0.15,                                   !- Thickness {m}
+  0.12,                                   !- Conductivity {W/m-K}
+  540,                                    !- Density {kg/m3}
+  1210,                                   !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:Surface,
+  {65ca1e41-d751-4fc6-8e81-bb84b0585e6f}, !- Handle
+  Perimeter_mid_ZN_4_Ceiling,             !- Name
+  RoofCeiling,                            !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {fd517fa4-3c26-440a-aa97-3ace8c1c83b8}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {424db90c-191f-42dc-891f-3050966dcf63}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 6.7056,                           !- X,Y,Z Vertex 1 {m}
+  4.5732, 4.5732, 6.7056,                 !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 6.7056,                !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 6.7056;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {a19a8ac6-9cd3-4882-b819-068c6ebdd97f}, !- Handle
+  MidFloor_Plenum_Floor_5,                !- Name
+  Floor,                                  !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {7b5df7a4-7bf7-4b0e-9c4c-233b5f3bc4d7}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {97040a33-8c54-4e3a-92db-805fd6eaad66}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 6.7056,               !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 6.7056,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 6.7056,                 !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 6.7056;                !- X,Y,Z Vertex 4 {m}
+
+OS:Building,
+  {ed36787e-0111-455c-a24c-be4262835f11}, !- Handle
+  Ref Bldg Medium Office New2004_v1.3_5.0, !- Name
+  ,                                       !- Building Sector Type
+  0,                                      !- North Axis {deg}
+  ,                                       !- Nominal Floor to Floor Height {m}
+  ,                                       !- Space Type Name
+  ,                                       !- Default Construction Set Name
+  ;                                       !- Default Schedule Set Name
+
+OS:RunPeriod,
+  {62304c4a-8407-4163-bae6-dba860197b4b}, !- Handle
+  Run Period 1,                           !- Name
+  1,                                      !- Begin Month
+  1,                                      !- Begin Day of Month
+  12,                                     !- End Month
+  31,                                     !- End Day of Month
+  No,                                     !- Use Weather File Holidays and Special Days
+  No,                                     !- Use Weather File Daylight Saving Period
+  No,                                     !- Apply Weekend Holiday Rule
+  Yes,                                    !- Use Weather File Rain Indicators
+  Yes,                                    !- Use Weather File Snow Indicators
+  1;                                      !- Number of Times Runperiod to be Repeated
+
+OS:YearDescription,
+  {0b3815bd-2335-48fe-8db3-ecc9c2ec3554}, !- Handle
+  ,                                       !- Calendar Year
+  Sunday;                                 !- Day of Week for Start Day
+
+OS:Surface,
+  {27d375f5-5356-4db9-ba90-a8a657f3b5e7}, !- Handle
+  Perimeter_mid_ZN_1_Ceiling,             !- Name
+  RoofCeiling,                            !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {bcf7adbf-62d7-4451-bd90-23e37f8bd918}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {4febb426-a532-4716-a858-35f93abd4e90}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 6.7056,                      !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 6.7056,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 6.7056,                 !- X,Y,Z Vertex 3 {m}
+  0, 0, 6.7056;                           !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {7d103038-a362-4dd4-886b-b11bfdd870a4}, !- Handle
+  Perimeter_mid_ZN_3_Ceiling,             !- Name
+  RoofCeiling,                            !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {ec891589-6c66-4218-912e-610c05f9fca6}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {453dc878-1de9-49ce-a86e-0a3e48dd74cb}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 6.7056,               !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 6.7056,                !- X,Y,Z Vertex 2 {m}
+  0, 33.2738, 6.7056,                     !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 6.7056;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {0d618067-41d2-4bfd-b9f8-b6a9b234c7b4}, !- Handle
+  TopFloor_Plenum_Floor_5,                !- Name
+  Floor,                                  !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {a6db022f-dfaa-45fa-9573-a2cb4bec5f66}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {39f66745-bb24-4ccc-8ef8-a7a5af95feea}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 10.668,               !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 10.668,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 10.668,                 !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 10.668;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {4278eb4f-8536-4876-8396-2197d716dd8c}, !- Handle
+  MidFloor_Plenum_Floor_2,                !- Name
+  Floor,                                  !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {7b5df7a4-7bf7-4b0e-9c4c-233b5f3bc4d7}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {956e619f-d76c-4b73-9fe3-44bbe0d012ad}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 6.7056,                !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 6.7056,                      !- X,Y,Z Vertex 2 {m}
+  45.3375, 4.5732, 6.7056,                !- X,Y,Z Vertex 3 {m}
+  45.3375, 28.7006, 6.7056;               !- X,Y,Z Vertex 4 {m}
+
+OS:Sizing:Parameters,
+  {ec157c9f-a54a-4d5f-adc4-7c7c764a00f2}, !- Handle
+  1.33,                                   !- Heating Sizing Factor
+  1.33,                                   !- Cooling Sizing Factor
+  6;                                      !- Timesteps in Averaging Window
+
+OS:Surface,
+  {3209fcd3-8cfc-4048-a8a1-95b494709e20}, !- Handle
+  Perimeter_mid_ZN_3_Floor,               !- Name
+  Floor,                                  !- Surface Type
+  {d24f1e89-cddb-4b47-9c0b-ae2ec431c1a6}, !- Construction Name
+  {ec891589-6c66-4218-912e-610c05f9fca6}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {dbf0dfa4-7e45-403f-a6cb-80fa964da6b6}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 3.9624,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 3.9624,               !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 3.9624,                !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 3.9624;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {1eb4308a-1c72-4ba1-8306-05c13e0baa91}, !- Handle
+  Perimeter_top_ZN_1_Floor,               !- Name
+  Floor,                                  !- Surface Type
+  {d24f1e89-cddb-4b47-9c0b-ae2ec431c1a6}, !- Construction Name
+  {4c8e12a9-92e8-4ff5-b054-f47863b51cf4}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {c58d6c74-2e5e-493d-b071-3d4a79718031}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 7.9248,                !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 7.9248,                      !- X,Y,Z Vertex 2 {m}
+  0, 0, 7.9248,                           !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 7.9248;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {b45a34b1-1722-4213-8b33-ab24a1a8c687}, !- Handle
+  Perimeter_mid_ZN_2_Wall_South,          !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {722a09e4-0646-4e5a-b78d-58b632bc69f7}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {a4afde50-40b0-453c-9817-a20848908c98}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 6.7056,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 3.9624,                !- X,Y,Z Vertex 2 {m}
+  49.911, 0, 3.9624,                      !- X,Y,Z Vertex 3 {m}
+  49.911, 0, 6.7056;                      !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {bce01acf-8760-4c6f-b164-976d317f0b5e}, !- Handle
+  Perimeter_bot_ZN_1_Ceiling,             !- Name
+  RoofCeiling,                            !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {dac06210-f4a7-4108-99da-b010224bcaf1}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {26934833-d66f-46f8-b52e-e1b2431e06a0}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 2.7432,                      !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 2.7432,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 2.7432,                 !- X,Y,Z Vertex 3 {m}
+  0, 0, 2.7432;                           !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {fa3477cf-6daa-43ea-87cc-ddffd9a4d3a9}, !- Handle
+  Perimeter_top_ZN_4_Wall_West_Window,    !- Name
+  FixedWindow,                            !- Sub Surface Type
+  {1bc32cfb-af5e-403d-a471-8f5c989f4a11}, !- Construction Name
+  {ba4569a8-b4b9-45d1-8e35-92980557579f}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  1,                                      !- Multiplier
+  ,                                       !- Number of Vertices
+  0, 33.2737, 10.2541,                    !- X,Y,Z Vertex 1 {m}
+  0, 33.2737, 8.9461,                     !- X,Y,Z Vertex 2 {m}
+  0, 0, 8.9461,                           !- X,Y,Z Vertex 3 {m}
+  0, 0, 10.2541;                          !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {ba4569a8-b4b9-45d1-8e35-92980557579f}, !- Handle
+  Perimeter_top_ZN_4_Wall_West,           !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {a47d34ed-7efc-47ea-bdaa-671d58f47564}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 33.2738, 10.668,                     !- X,Y,Z Vertex 1 {m}
+  0, 33.2738, 7.9248,                     !- X,Y,Z Vertex 2 {m}
+  0, 0, 7.9248,                           !- X,Y,Z Vertex 3 {m}
+  0, 0, 10.668;                           !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {88ccce13-3ada-47fc-b4d8-5248dc1dadde}, !- Handle
+  Perimeter_top_ZN_3_Floor,               !- Name
+  Floor,                                  !- Surface Type
+  {d24f1e89-cddb-4b47-9c0b-ae2ec431c1a6}, !- Construction Name
+  {67aa5b71-cfb3-4a14-86b6-9f9ba9a407f8}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {17f19611-089d-40f4-a913-e72440fee3e6}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 7.9248,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 7.9248,               !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 7.9248,                !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 7.9248;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {83416424-96d6-4f14-89be-24a065146140}, !- Handle
+  Perimeter_mid_ZN_3_Wall_North,          !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {ec891589-6c66-4218-912e-610c05f9fca6}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 6.7056,                !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 3.9624,                !- X,Y,Z Vertex 2 {m}
+  0, 33.2738, 3.9624,                     !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 6.7056;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {08535030-e524-4f71-8ef9-c56906523e1a}, !- Handle
+  FirstFloor_Plenum_Ceiling_1,            !- Name
+  RoofCeiling,                            !- Surface Type
+  {d2639f93-4cc4-4eee-90ec-1f31812be744}, !- Construction Name
+  {af409fa8-d6d1-4cb3-ab07-78dd65cb9800}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {16f1f70c-ea26-43ef-834d-435d30364c4c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 3.9624,                      !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 3.9624,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 3.9624,                 !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.9624;                           !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {e8e12431-b8bd-440e-914e-2a54469fdc8d}, !- Handle
+  Perimeter_bot_ZN_4_Wall_West_Window,    !- Name
+  FixedWindow,                            !- Sub Surface Type
+  {1bc32cfb-af5e-403d-a471-8f5c989f4a11}, !- Construction Name
+  {8efef24a-80d8-4f06-ab27-e51f2a68056b}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  1,                                      !- Multiplier
+  ,                                       !- Number of Vertices
+  0, 33.2737, 2.3293,                     !- X,Y,Z Vertex 1 {m}
+  0, 33.2737, 1.0213,                     !- X,Y,Z Vertex 2 {m}
+  0, 0, 1.0213,                           !- X,Y,Z Vertex 3 {m}
+  0, 0, 2.3293;                           !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {f6f8401d-43b6-4c1b-b872-99194b5771e9}, !- Handle
+  Perimeter_bot_ZN_4_Wall_South,          !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {27fdb3c4-855f-48df-983a-24f85fe57204}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {72d07376-ee0f-4e41-b355-ef18b1e157b8}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 2.7432,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 0,                      !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 2.7432;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Material,
+  {c28045cd-37b2-4189-a8ec-bec637cb84d8}, !- Handle
+  Metal Roofing,                          !- Name
+  MediumSmooth,                           !- Roughness
+  0.0015,                                 !- Thickness {m}
+  45.006,                                 !- Conductivity {W/m-K}
+  7680,                                   !- Density {kg/m3}
+  418.4,                                  !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.3;                                    !- Visible Absorptance
+
+OS:Surface,
+  {dbf0dfa4-7e45-403f-a6cb-80fa964da6b6}, !- Handle
+  FirstFloor_Plenum_Ceiling_3,            !- Name
+  RoofCeiling,                            !- Surface Type
+  {d2639f93-4cc4-4eee-90ec-1f31812be744}, !- Construction Name
+  {af409fa8-d6d1-4cb3-ab07-78dd65cb9800}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {3209fcd3-8cfc-4048-a8a1-95b494709e20}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 3.9624,               !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 3.9624,                !- X,Y,Z Vertex 2 {m}
+  0, 33.2738, 3.9624,                     !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 3.9624;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {778f8aa0-9aa4-4818-87a4-34cf41f4c45f}, !- Handle
+  TopFloor_Plenum_Floor_3,                !- Name
+  Floor,                                  !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {a6db022f-dfaa-45fa-9573-a2cb4bec5f66}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {6c8b7465-4702-4e73-8e68-4218cd0aaf80}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 10.668,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 10.668,               !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 10.668,                !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 10.668;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {1e08d663-4124-4ab7-b91e-9601eb81a428}, !- Handle
+  Perimeter_top_ZN_2_Wall_West,           !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {eb32a2fb-5981-48a3-a152-e410cbe800cd}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {cf9c8df3-e6c1-47f4-91a8-b20dcc9d2508}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 10.668,               !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 7.9248,               !- X,Y,Z Vertex 2 {m}
+  45.3375, 4.5732, 7.9248,                !- X,Y,Z Vertex 3 {m}
+  45.3375, 4.5732, 10.668;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {4febb426-a532-4716-a858-35f93abd4e90}, !- Handle
+  MidFloor_Plenum_Floor_1,                !- Name
+  Floor,                                  !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {7b5df7a4-7bf7-4b0e-9c4c-233b5f3bc4d7}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {27d375f5-5356-4db9-ba90-a8a657f3b5e7}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 6.7056,                !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 6.7056,                      !- X,Y,Z Vertex 2 {m}
+  0, 0, 6.7056,                           !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 6.7056;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {d3b3e593-ab36-48cf-9b7a-c710daed9530}, !- Handle
+  Perimeter_bot_ZN_3_Wall_East,           !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {c7f6e37f-54b9-4246-b00b-8ba5739f031d}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {0723f01d-e17b-495b-bd34-61016872d5f7}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 2.7432,               !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 0,                    !- X,Y,Z Vertex 2 {m}
+  49.911, 33.2738, 0,                     !- X,Y,Z Vertex 3 {m}
+  49.911, 33.2738, 2.7432;                !- X,Y,Z Vertex 4 {m}
+
+OS:ShadowCalculation,
+  {36bc3606-8fc7-4da4-910e-ae153dc84911}, !- Handle
+  7,                                      !- Calculation Frequency
+  15000;                                  !- Maximum Figures in Shadow Overlap Calculations
+
+OS:Surface,
+  {3edb3dc0-7f5c-4e0f-8598-412854bf4412}, !- Handle
+  Perimeter_mid_ZN_4_Floor,               !- Name
+  Floor,                                  !- Surface Type
+  {d24f1e89-cddb-4b47-9c0b-ae2ec431c1a6}, !- Construction Name
+  {fd517fa4-3c26-440a-aa97-3ace8c1c83b8}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {ed837c7d-a8d1-48a6-8eef-6bed72d42925}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 33.2738, 3.9624,                     !- X,Y,Z Vertex 1 {m}
+  4.5732, 28.7006, 3.9624,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 3.9624,                 !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.9624;                           !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {0eade2fb-cfbc-458f-aab2-a32566bec56d}, !- Handle
+  Perimeter_top_ZN_4_Wall_North,          !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {a47d34ed-7efc-47ea-bdaa-671d58f47564}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {c9895b27-179a-4471-9ab3-f80539d3a631}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  4.5732, 28.7006, 10.668,                !- X,Y,Z Vertex 1 {m}
+  4.5732, 28.7006, 7.9248,                !- X,Y,Z Vertex 2 {m}
+  0, 33.2738, 7.9248,                     !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 10.668;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {1483f84a-a496-44bf-b640-f5e115ab3168}, !- Handle
+  Perimeter_top_Plenum_Wall_East,         !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {a6db022f-dfaa-45fa-9573-a2cb4bec5f66}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 11.8872,                     !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 10.668,                      !- X,Y,Z Vertex 2 {m}
+  49.911, 33.2738, 10.668,                !- X,Y,Z Vertex 3 {m}
+  49.911, 33.2738, 11.8872;               !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {64e092f7-fac8-4c55-94b6-f063d55be81f}, !- Handle
+  Perimeter_mid_ZN_4_Wall_South,          !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {fd517fa4-3c26-440a-aa97-3ace8c1c83b8}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {ff6a02f2-f53d-444f-98b8-0a577fc698a1}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 6.7056,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.9624,                           !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 3.9624,                 !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 6.7056;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {c0de71ed-6430-4976-bfb7-bb9409c60843}, !- Handle
+  TopFloor_Plenum_Floor_1,                !- Name
+  Floor,                                  !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {a6db022f-dfaa-45fa-9573-a2cb4bec5f66}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {2a6df47f-9a0f-4c06-aeee-edfa69f5149b}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 10.668,                !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 10.668,                      !- X,Y,Z Vertex 2 {m}
+  0, 0, 10.668,                           !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 10.668;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {287e05fd-63e9-4119-9fd8-48bb2ee44440}, !- Handle
+  Perimeter_top_ZN_2_Floor,               !- Name
+  Floor,                                  !- Surface Type
+  {d24f1e89-cddb-4b47-9c0b-ae2ec431c1a6}, !- Construction Name
+  {eb32a2fb-5981-48a3-a152-e410cbe800cd}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {fe7ad4a5-554d-4268-8179-77f7780ee204}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 7.9248,                !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 7.9248,                      !- X,Y,Z Vertex 2 {m}
+  45.3375, 4.5732, 7.9248,                !- X,Y,Z Vertex 3 {m}
+  45.3375, 28.7006, 7.9248;               !- X,Y,Z Vertex 4 {m}
+
+OS:Timestep,
+  {b0fa043b-3e91-4705-b798-a26bbea47620}, !- Handle
+  6;                                      !- Number of Timesteps per Hour
+
+OS:Surface,
+  {af9a19d0-4115-4c85-a9f9-266ec4973890}, !- Handle
+  Core_bot_ZN_5_Wall_North,               !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {0301d7f6-33a7-4967-9d2b-ab9b1cfbe5aa}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {3a20baa7-ba7c-49f9-9b77-cab260cad18d}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 2.7432,               !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 0,                    !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 0,                     !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 2.7432;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {716e8614-0037-4a42-99c3-634d9645608b}, !- Handle
+  Core_mid_ZN_5_Wall_South,               !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {493f6d08-7166-456d-ac62-2aa6ae1e0923}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {88ceb210-970e-406c-975f-93c3b142b72b}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  4.5732, 4.5732, 6.7056,                 !- X,Y,Z Vertex 1 {m}
+  4.5732, 4.5732, 3.9624,                 !- X,Y,Z Vertex 2 {m}
+  45.3375, 4.5732, 3.9624,                !- X,Y,Z Vertex 3 {m}
+  45.3375, 4.5732, 6.7056;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {475104a5-3781-41de-b09f-706fd82184d0}, !- Handle
+  FirstFloor_Plenum_Ceiling_2,            !- Name
+  RoofCeiling,                            !- Surface Type
+  {d2639f93-4cc4-4eee-90ec-1f31812be744}, !- Construction Name
+  {af409fa8-d6d1-4cb3-ab07-78dd65cb9800}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {4d501b81-344c-4ade-b8c3-2032b7b438a6}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 3.9624,                      !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 3.9624,                !- X,Y,Z Vertex 2 {m}
+  45.3375, 28.7006, 3.9624,               !- X,Y,Z Vertex 3 {m}
+  45.3375, 4.5732, 3.9624;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {4de4d18e-cfa0-4a45-b7e2-061b3c5cc693}, !- Handle
+  Perimeter_mid_ZN_3_Wall_West,           !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {ec891589-6c66-4218-912e-610c05f9fca6}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {084d45e2-b21a-428c-96c2-ab7001d364ad}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 33.2738, 6.7056,                     !- X,Y,Z Vertex 1 {m}
+  0, 33.2738, 3.9624,                     !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 3.9624,                !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 6.7056;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {7b1703fe-1a29-4c1d-811a-5a82464bc284}, !- Handle
+  Core_top_ZN_5_Wall_West,                !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {b422ea64-bad8-4f36-9616-c0c97070580c}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {49211562-7b70-470e-b1a2-79aeb11ef499}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  4.5732, 28.7006, 10.668,                !- X,Y,Z Vertex 1 {m}
+  4.5732, 28.7006, 7.9248,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 7.9248,                 !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 10.668;                 !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {a93c4408-defb-4eb6-8225-5d01c660516e}, !- Handle
+  Perimeter_mid_ZN_3_Wall_North_Window,   !- Name
+  FixedWindow,                            !- Sub Surface Type
+  {1bc32cfb-af5e-403d-a471-8f5c989f4a11}, !- Construction Name
+  {83416424-96d6-4f14-89be-24a065146140}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Shading Control Name
+  ,                                       !- Frame and Divider Name
+  1,                                      !- Multiplier
+  ,                                       !- Number of Vertices
+  49.91, 33.2738, 6.2917,                 !- X,Y,Z Vertex 1 {m}
+  49.91, 33.2738, 4.9837,                 !- X,Y,Z Vertex 2 {m}
+  0, 33.2738, 4.9837,                     !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 6.2917;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {f73e9304-b61a-4029-a354-099567b23887}, !- Handle
+  FirstFloor_Plenum_Floor_4,              !- Name
+  Floor,                                  !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {af409fa8-d6d1-4cb3-ab07-78dd65cb9800}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {f71b1ec4-102c-4010-840f-71d9fe8d68bd}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 33.2738, 2.7432,                     !- X,Y,Z Vertex 1 {m}
+  4.5732, 28.7006, 2.7432,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 2.7432,                 !- X,Y,Z Vertex 3 {m}
+  0, 0, 2.7432;                           !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {bf2f74c2-13aa-4f17-b0ac-99007991d87a}, !- Handle
+  Perimeter_mid_Plenum_Wall_East,         !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {7b5df7a4-7bf7-4b0e-9c4c-233b5f3bc4d7}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 0, 7.9248,                      !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 6.7056,                      !- X,Y,Z Vertex 2 {m}
+  49.911, 33.2738, 6.7056,                !- X,Y,Z Vertex 3 {m}
+  49.911, 33.2738, 7.9248;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {04828872-5aee-42c2-ac8c-4d56fde3586c}, !- Handle
+  Core_bottom_ceiling,                    !- Name
+  RoofCeiling,                            !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {0301d7f6-33a7-4967-9d2b-ab9b1cfbe5aa}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {c1930421-c933-405a-bbdf-a9d912313c7d}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 2.7432,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 2.7432,               !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 2.7432,                !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 2.7432;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {830c7392-9ab2-4959-9004-29160e6a8d75}, !- Handle
+  Core_mid_ZN_5_Floor,                    !- Name
+  Floor,                                  !- Surface Type
+  {d24f1e89-cddb-4b47-9c0b-ae2ec431c1a6}, !- Construction Name
+  {493f6d08-7166-456d-ac62-2aa6ae1e0923}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {7a1ce153-6a0f-4f11-bd9c-6f312bb90ffb}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 28.7006, 3.9624,               !- X,Y,Z Vertex 1 {m}
+  45.3375, 4.5732, 3.9624,                !- X,Y,Z Vertex 2 {m}
+  4.5732, 4.5732, 3.9624,                 !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 3.9624;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {49580853-55de-498d-9d0e-811818c9f19f}, !- Handle
+  Perimeter_mid_Plenum_Wall_North,        !- Name
+  Wall,                                   !- Surface Type
+  {5cca2d40-570b-497a-82a6-0dc91d7ed2e6}, !- Construction Name
+  {7b5df7a4-7bf7-4b0e-9c4c-233b5f3bc4d7}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 7.9248,                !- X,Y,Z Vertex 1 {m}
+  49.911, 33.2738, 6.7056,                !- X,Y,Z Vertex 2 {m}
+  0, 33.2738, 6.7056,                     !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 7.9248;                     !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {6d86e43c-32bc-416a-9c07-2a14be8ca993}, !- Handle
+  Perimeter_bot_ZN_3_Floor,               !- Name
+  Floor,                                  !- Surface Type
+  {4f011101-a6b7-4cde-98e5-2d67029d02d0}, !- Construction Name
+  {c7f6e37f-54b9-4246-b00b-8ba5739f031d}, !- Space Name
+  Ground,                                 !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 0,                     !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 0,                    !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 0,                     !- X,Y,Z Vertex 3 {m}
+  0, 33.2738, 0;                          !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {39f66745-bb24-4ccc-8ef8-a7a5af95feea}, !- Handle
+  Core_top_ZN_5_Ceiling,                  !- Name
+  RoofCeiling,                            !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {b422ea64-bad8-4f36-9616-c0c97070580c}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {0d618067-41d2-4bfd-b9f8-b6a9b234c7b4}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  45.3375, 4.5732, 10.668,                !- X,Y,Z Vertex 1 {m}
+  45.3375, 28.7006, 10.668,               !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 10.668,                !- X,Y,Z Vertex 3 {m}
+  4.5732, 4.5732, 10.668;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {96c0d38b-45dd-4d4d-83ed-7371f075cf56}, !- Handle
+  Perimeter_bot_ZN_3_Wall_West,           !- Name
+  Wall,                                   !- Surface Type
+  {e36f0e69-0dcd-4575-87ed-6a81ac714f3c}, !- Construction Name
+  {c7f6e37f-54b9-4246-b00b-8ba5739f031d}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {576d1f61-9b9f-4ad0-95e7-c20abfa77214}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 33.2738, 2.7432,                     !- X,Y,Z Vertex 1 {m}
+  0, 33.2738, 0,                          !- X,Y,Z Vertex 2 {m}
+  4.5732, 28.7006, 0,                     !- X,Y,Z Vertex 3 {m}
+  4.5732, 28.7006, 2.7432;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {79c19edf-9c28-4804-a251-5943f81cbcee}, !- Handle
+  FirstFloor_Plenum_Floor_2,              !- Name
+  Floor,                                  !- Surface Type
+  {d4b230ae-d540-4029-8ff6-ef951beffbbf}, !- Construction Name
+  {af409fa8-d6d1-4cb3-ab07-78dd65cb9800}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {d6273170-f5e5-41d7-919f-8167938886ad}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  49.911, 33.2738, 2.7432,                !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 2.7432,                      !- X,Y,Z Vertex 2 {m}
+  45.3375, 4.5732, 2.7432,                !- X,Y,Z Vertex 3 {m}
+  45.3375, 28.7006, 2.7432;               !- X,Y,Z Vertex 4 {m}
+
+OS:ClimateZones,
+  {3aff5296-c4f0-4ffd-9b46-5c92bbedd260}, !- Handle
+  ,                                       !- Active Institution
+  ,                                       !- Active Year
+  ASHRAE,                                 !- Climate Zone Institution Name 1
+  ANSI/ASHRAE Standard 169,               !- Climate Zone Document Name 1
+  2006,                                   !- Climate Zone Document Year 1
+  ,                                       !- Climate Zone Value 1
+  CEC,                                    !- Climate Zone Institution Name 2
+  California Climate Zone Descriptions,   !- Climate Zone Document Name 2
+  1995,                                   !- Climate Zone Document Year 2
+  ;                                       !- Climate Zone Value 2
+
+OS:LifeCycleCost:Parameters,
+  {01cfb60e-f379-40f6-a048-f4cebd282760}, !- Handle
+  FEMP,                                   !- Analysis Type
+  ,                                       !- Discounting Convention
+  ,                                       !- Inflation Approach
+  ,                                       !- Real Discount Rate
+  ,                                       !- Nominal Discount Rate
+  ,                                       !- Inflation
+  ,                                       !- Base Date Month
+  ,                                       !- Base Date Year
+  ,                                       !- Service Date Month
+  ,                                       !- Service Date Year
+  ,                                       !- Length of Study Period in Years
+  ,                                       !- Tax Rate
+  ,                                       !- Depreciation Method
+  Yes;                                    !- Use NIST Fuel Escalation Rates
+
+OS:Facility,
+  {05664c6f-a9a8-49d2-8f53-4515d5b8d42a}; !- Handle
+

--- a/create_DOE_prototype_building/resources/HVACSizing.ConstructionSetGenerator.rb
+++ b/create_DOE_prototype_building/resources/HVACSizing.ConstructionSetGenerator.rb
@@ -12,13 +12,13 @@ def initialize(path_to_standards_json)
   @standards = {}
   temp = File.read(path_to_standards_json.to_s)
   @standards = JSON.parse(temp)
-  @construction_sets = @standards["construction_sets"]
-  @constructions = @standards["constructions"]
-  @materials = @standards["materials"]
-  @climate_zone_sets = @standards["climate_zone_sets"]
-  @climate_zones = @standards["climate_zones"]
+  @construction_sets = @standards['construction_sets']
+  @constructions = @standards['constructions']
+  @materials = @standards['materials']
+  @climate_zone_sets = @standards['climate_zone_sets']
+  @climate_zones = @standards['climate_zones']
   if @construction_sets.nil? or @constructions.nil? or @materials.nil? or @climate_zone_sets.nil? or @climate_zones.nil?
-    puts "The standards json file did not load correctly."
+    puts 'The standards json file did not load correctly.'
     exit
   end
 
@@ -27,45 +27,45 @@ end
 
 def make_name(template, clim, building_type, spc_type)
 
-  clim = clim.gsub("ClimateZone ", "CZ")
-  if clim == "CZ1-8"
-    clim = ""
+  clim = clim.gsub('ClimateZone ', 'CZ')
+  if clim == 'CZ1-8'
+    clim = ''
   end
   
-  if building_type == "FullServiceRestaurant"
-    building_type = "FullSrvRest"
-  elsif building_type == "Hospital"
-    building_type = "Hospital"
-  elsif building_type == "LargeHotel"
-    building_type = "LrgHotel"
-  elsif building_type == "LargeOffice"
-    building_type = "LrgOffice"
-  elsif building_type == "MediumOffice"
-    building_type = "MedOffice"
-  elsif building_type == "Mid-riseApartment"
-    building_type = "MidApt"
-  elsif building_type == "Office"
-    building_type = "Office"
-  elsif building_type == "Outpatient"
-    building_type = "Outpatient"
-  elsif building_type == "PrimarySchool"
-    building_type = "PriSchl"
-  elsif building_type == "QuickServiceRestaurant"
-    building_type = "QckSrvRest"
-  elsif building_type == "Retail"
-    building_type = "Retail"
-  elsif building_type == "SecondarySchool"
-    building_type = "SecSchl"
-  elsif building_type == "SmallHotel"
-    building_type = "SmHotel"
-  elsif building_type == "SmallOffice"
-    building_type = "SmOffice"
-  elsif building_type == "StripMall"
-    building_type = "StMall"
-  elsif building_type == "SuperMarket"
-    building_type = "SpMarket"
-  elsif building_type == "Warehouse"
-    building_type = "Warehouse"
+  if building_type == 'FullServiceRestaurant'
+    building_type = 'FullSrvRest'
+  elsif building_type == 'Hospital'
+    building_type = 'Hospital'
+  elsif building_type == 'LargeHotel'
+    building_type = 'LrgHotel'
+  elsif building_type == 'LargeOffice'
+    building_type = 'LrgOffice'
+  elsif building_type == 'MediumOffice'
+    building_type = 'MedOffice'
+  elsif building_type == 'Mid-riseApartment'
+    building_type = 'MidApt'
+  elsif building_type == 'Office'
+    building_type = 'Office'
+  elsif building_type == 'Outpatient'
+    building_type = 'Outpatient'
+  elsif building_type == 'PrimarySchool'
+    building_type = 'PriSchl'
+  elsif building_type == 'QuickServiceRestaurant'
+    building_type = 'QckSrvRest'
+  elsif building_type == 'Retail'
+    building_type = 'Retail'
+  elsif building_type == 'SecondarySchool'
+    building_type = 'SecSchl'
+  elsif building_type == 'SmallHotel'
+    building_type = 'SmHotel'
+  elsif building_type == 'SmallOffice'
+    building_type = 'SmOffice'
+  elsif building_type == 'StripMall'
+    building_type = 'StMall'
+  elsif building_type == 'SuperMarket'
+    building_type = 'SpMarket'
+  elsif building_type == 'Warehouse'
+    building_type = 'Warehouse'
   end
   
   parts = [template]
@@ -97,71 +97,71 @@ end
 def make_material(material_name, data, model)  
 
   material = nil
-  material_type = data["material_type"]
+  material_type = data['material_type']
   
-  if material_type == "StandardOpaqueMaterial"
+  if material_type == 'StandardOpaqueMaterial'
     material = OpenStudio::Model::StandardOpaqueMaterial.new(model)
     material.setName(material_name)
     
-    material.setRoughness(data["roughness"].to_s)
-    material.setThickness(OpenStudio::convert(data["thickness"].to_f, "in", "m").get)
-    material.setConductivity(OpenStudio::convert(data["conductivity"].to_f, "Btu*in/hr*ft^2*R", "W/m*K").get)
-    material.setDensity(OpenStudio::convert(data["density"].to_f, "lb/ft^3", "kg/m^3").get)
-    material.setSpecificHeat(OpenStudio::convert(data["specific_heat"].to_f, "Btu/lb*R", "J/kg*K").get)
-    material.setThermalAbsorptance(data["thermal_absorptance"].to_f)
-    material.setSolarAbsorptance(data["solar_absorptance"].to_f)
-    material.setVisibleAbsorptance(data["visible_absorptance"].to_f)
+    material.setRoughness(data['roughness'].to_s)
+    material.setThickness(OpenStudio::convert(data['thickness'].to_f, 'in', 'm').get)
+    material.setConductivity(OpenStudio::convert(data['conductivity'].to_f, 'Btu*in/hr*ft^2*R', 'W/m*K').get)
+    material.setDensity(OpenStudio::convert(data['density'].to_f, 'lb/ft^3', 'kg/m^3').get)
+    material.setSpecificHeat(OpenStudio::convert(data['specific_heat'].to_f, 'Btu/lb*R', 'J/kg*K').get)
+    material.setThermalAbsorptance(data['thermal_absorptance'].to_f)
+    material.setSolarAbsorptance(data['solar_absorptance'].to_f)
+    material.setVisibleAbsorptance(data['visible_absorptance'].to_f)
     
-  elsif material_type == "MasslessOpaqueMaterial" 
+  elsif material_type == 'MasslessOpaqueMaterial'
     material = OpenStudio::Model::MasslessOpaqueMaterial.new(model)
     material.setName(material_name)
     
-    material.setConductivity(OpenStudio::convert(data["conductivity"].to_f, "Btu*in/hr*ft^2*R", "W/m*K").get)
-    material.setDensity(OpenStudio::convert(data["density"].to_f, "lb/ft^3", "kg/m^3").get)
-    material.setSpecificHeat(OpenStudio::convert(data["specific_heat"].to_f, "Btu/lb*R", "J/kg*K").get)
-    material.setThermalAbsorptance(data["thermal_absorptance"].to_f)
-    material.setSolarAbsorptance(data["solar_absorptance"].to_f)
-    material.setVisibleAbsorptance(data["visible_absorptance"].to_f)
+    material.setConductivity(OpenStudio::convert(data['conductivity'].to_f, 'Btu*in/hr*ft^2*R', 'W/m*K').get)
+    material.setDensity(OpenStudio::convert(data['density'].to_f, 'lb/ft^3', 'kg/m^3').get)
+    material.setSpecificHeat(OpenStudio::convert(data['specific_heat'].to_f, 'Btu/lb*R', 'J/kg*K').get)
+    material.setThermalAbsorptance(data['thermal_absorptance'].to_f)
+    material.setSolarAbsorptance(data['solar_absorptance'].to_f)
+    material.setVisibleAbsorptance(data['visible_absorptance'].to_f)
     
-  elsif material_type == "AirGap"
+  elsif material_type == 'AirGap'
     material = OpenStudio::Model::AirGap.new(model)
     material.setName(material_name)
     
-    material.setThermalResistance(OpenStudio::convert(data["resistance"].to_f, "hr*ft^2*R/Btu*in", "m*K/W").get)
+    material.setThermalResistance(OpenStudio::convert(data['resistance'].to_f, 'hr*ft^2*R/Btu*in', 'm*K/W').get)
 
-  elsif material_type == "Gas"
+  elsif material_type == 'Gas'
     material = OpenStudio::Model::Gas.new(model)
     material.setName(material_name)
 
-    material.setThickness(OpenStudio::convert(data["thickness"].to_f, "in", "m").get)
-    material.setGasType(data["gas_type"].to_s)
+    material.setThickness(OpenStudio::convert(data['thickness'].to_f, 'in', 'm').get)
+    material.setGasType(data['gas_type'].to_s)
     
-  elsif material_type == "SimpleGlazing" 
+  elsif material_type == 'SimpleGlazing'
     material = OpenStudio::Model::SimpleGlazing.new(model)
     material.setName(material_name)
     
-    material.setUFactor(OpenStudio::convert(data["u_factor"].to_f, "Btu/hr*ft^2*R", "W/m^2*K").get)
-    material.setSolarHeatGainCoefficient(data["solar_heat_gain_coefficient"].to_f)
-    material.setVisibleTransmittance(data["visible_transmittance"].to_f)
+    material.setUFactor(OpenStudio::convert(data['u_factor'].to_f, 'Btu/hr*ft^2*R', 'W/m^2*K').get)
+    material.setSolarHeatGainCoefficient(data['solar_heat_gain_coefficient'].to_f)
+    material.setVisibleTransmittance(data['visible_transmittance'].to_f)
 
-  elsif material_type == "StandardGlazing" 
+  elsif material_type == 'StandardGlazing'
     material = OpenStudio::Model::StandardGlazing.new(model)
     material.setName(material_name)
     
-    material.setOpticalDataType(data["optical_data_type"].to_s)
-    material.setThickness(OpenStudio::convert(data["thickness"].to_f, "in", "m").get)
-    material.setSolarTransmittanceatNormalIncidence(data["solar_transmittance_at_normal_incidence"].to_f)
-    material.setFrontSideSolarReflectanceatNormalIncidence(data["front_side_solar_reflectance_at_normal_incidence"].to_f)
-    material.setBackSideSolarReflectanceatNormalIncidence(data["back_side_solar_reflectance_at_normal_incidence"].to_f)
-    material.setVisibleTransmittanceatNormalIncidence(data["visible_transmittance_at_normal_incidence"].to_f)
-    material.setFrontSideVisibleReflectanceatNormalIncidence(data["front_side_visible_reflectance_at_normal_incidence"].to_f)
-    material.setBackSideVisibleReflectanceatNormalIncidence(data["back_side_visible_reflectance_at_normal_incidence"].to_f)
-    material.setInfraredTransmittanceatNormalIncidence(data["infrared_transmittance_at_normal_incidence"].to_f)
-    material.setFrontSideInfraredHemisphericalEmissivity(data["front_side_infrared_hemispherical_emissivity"].to_f)
-    material.setBackSideInfraredHemisphericalEmissivity(data["back_side_infrared_hemispherical_emissivity"].to_f) 
-    material.setConductivity(OpenStudio::convert(data["conductivity"].to_f, "Btu*in/hr*ft^2*R", "W/m*K").get)
-    material.setDirtCorrectionFactorforSolarandVisibleTransmittance(data["dirt_correction_factor_for_solar_and_visible_transmittance"].to_f) 
-    if /true/i.match(data["solar_diffusing"].to_s)
+    material.setOpticalDataType(data['optical_data_type'].to_s)
+    material.setThickness(OpenStudio::convert(data['thickness'].to_f, 'in', 'm').get)
+    material.setSolarTransmittanceatNormalIncidence(data['solar_transmittance_at_normal_incidence'].to_f)
+    material.setFrontSideSolarReflectanceatNormalIncidence(data['front_side_solar_reflectance_at_normal_incidence'].to_f)
+    material.setBackSideSolarReflectanceatNormalIncidence(data['back_side_solar_reflectance_at_normal_incidence'].to_f)
+    material.setVisibleTransmittanceatNormalIncidence(data['visible_transmittance_at_normal_incidence'].to_f)
+    material.setFrontSideVisibleReflectanceatNormalIncidence(data['front_side_visible_reflectance_at_normal_incidence'].to_f)
+    material.setBackSideVisibleReflectanceatNormalIncidence(data['back_side_visible_reflectance_at_normal_incidence'].to_f)
+    material.setInfraredTransmittanceatNormalIncidence(data['infrared_transmittance_at_normal_incidence'].to_f)
+    material.setFrontSideInfraredHemisphericalEmissivity(data['front_side_infrared_hemispherical_emissivity'].to_f)
+    material.setBackSideInfraredHemisphericalEmissivity(data['back_side_infrared_hemispherical_emissivity'].to_f)
+    material.setConductivity(OpenStudio::convert(data['conductivity'].to_f, 'Btu*in/hr*ft^2*R', 'W/m*K').get)
+    material.setDirtCorrectionFactorforSolarandVisibleTransmittance(data['dirt_correction_factor_for_solar_and_visible_transmittance'].to_f)
+    if /true/i.match(data['solar_diffusing'].to_s)
       material.setSolarDiffusing(true) 
     else
       material.setSolarDiffusing(false)
@@ -198,22 +198,22 @@ def make_construction(construction_name, data, model)
   
   standards_info = construction.standardsInformation
   
-  intended_surface_type = data["intended_surface_type"]
+  intended_surface_type = data['intended_surface_type']
   if not intended_surface_type
-    intended_surface_type = ""
+    intended_surface_type = ''
   end
   standards_info.setIntendedSurfaceType(intended_surface_type)
   
-  standards_construction_type = data["standards_construction_type"]
+  standards_construction_type = data['standards_construction_type']
   if not standards_construction_type
-    standards_construction_type = ""
+    standards_construction_type = ''
   end
   standards_info.setStandardsConstructionType(standards_construction_type)
   
   #TODO: could put color in the spreadsheet
   
   layers = OpenStudio::Model::MaterialVector.new
-  data["materials"].each do |material_name|
+  data['materials'].each do |material_name|
     layers << get_material(material_name, model)
   end
   construction.setLayers(layers)
@@ -270,7 +270,7 @@ def find_climate_zone_set(template, clim, building_type, spc_type)
           if not result
             result = possible_climate_zone_set
           else
-            puts "Error, climate zone contained in multiple climate zone sets"
+            puts 'Error, climate zone contained in multiple climate zone sets'
           end
         end
       end
@@ -311,94 +311,94 @@ def generate_construction_set(template, clim, building_type, spc_type, model = n
   # exterior surfaces constructions
   exterior_surfaces = OpenStudio::Model::DefaultSurfaceConstructions.new(model)
   construction_set.setDefaultExteriorSurfaceConstructions(exterior_surfaces)
-  if construction_name = data["exterior_floor"]
+  if construction_name = data['exterior_floor']
     exterior_surfaces.setFloorConstruction(get_construction(construction_name, model))
   end      
-  if construction_name = data["exterior_wall"]
+  if construction_name = data['exterior_wall']
     exterior_surfaces.setWallConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["exterior_roof"]
+  if construction_name = data['exterior_roof']
     exterior_surfaces.setRoofCeilingConstruction(get_construction(construction_name, model))
   end    
   
   # interior surfaces constructions
   interior_surfaces = OpenStudio::Model::DefaultSurfaceConstructions.new(model)
   construction_set.setDefaultInteriorSurfaceConstructions(interior_surfaces)
-  if construction_name = data["interior_floor"]
+  if construction_name = data['interior_floor']
     interior_surfaces.setFloorConstruction(get_construction(construction_name, model))
   end      
-  if construction_name = data["interior_wall"]
+  if construction_name = data['interior_wall']
     interior_surfaces.setWallConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["interior_ceiling"]
+  if construction_name = data['interior_ceiling']
     interior_surfaces.setRoofCeilingConstruction(get_construction(construction_name, model))
   end  
   
   # ground contact surfaces constructions
   ground_surfaces = OpenStudio::Model::DefaultSurfaceConstructions.new(model)
   construction_set.setDefaultGroundContactSurfaceConstructions(ground_surfaces)
-  if construction_name = data["ground_contact_floor"]
+  if construction_name = data['ground_contact_floor']
     ground_surfaces.setFloorConstruction(get_construction(construction_name, model))
   end      
-  if construction_name = data["ground_contact_wall"]
+  if construction_name = data['ground_contact_wall']
     ground_surfaces.setWallConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["ground_contact_ceiling"]
+  if construction_name = data['ground_contact_ceiling']
     ground_surfaces.setRoofCeilingConstruction(get_construction(construction_name, model))
   end
   
   # exterior sub surfaces constructions
   exterior_subsurfaces = OpenStudio::Model::DefaultSubSurfaceConstructions.new(model)
   construction_set.setDefaultExteriorSubSurfaceConstructions(exterior_subsurfaces)
-  if construction_name = data["exterior_fixed_window"]
+  if construction_name = data['exterior_fixed_window']
     exterior_subsurfaces.setFixedWindowConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["exterior_operable_window"]
+  if construction_name = data['exterior_operable_window']
     exterior_subsurfaces.setOperableWindowConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["exterior_door"]
+  if construction_name = data['exterior_door']
     exterior_subsurfaces.setDoorConstruction(get_construction(construction_name, model))
   end  
-  if construction_name = data["exterior_glass_door"]
+  if construction_name = data['exterior_glass_door']
     exterior_subsurfaces.setGlassDoorConstruction(get_construction(construction_name, model))
   end  
-  if construction_name = data["exterior_overhead_door"]
+  if construction_name = data['exterior_overhead_door']
     exterior_subsurfaces.setOverheadDoorConstruction(get_construction(construction_name, model))
   end  
-  if construction_name = data["exterior_skylight"]
+  if construction_name = data['exterior_skylight']
     exterior_subsurfaces.setOverheadDoorConstruction(get_construction(construction_name, model))
   end  
-  if construction_name = data["tubular_daylight_dome"]
+  if construction_name = data['tubular_daylight_dome']
     exterior_subsurfaces.setTubularDaylightDomeConstruction(get_construction(construction_name, model))
   end  
-  if construction_name = data["tubular_daylight_diffuser"]
+  if construction_name = data['tubular_daylight_diffuser']
     exterior_subsurfaces.setTubularDaylightDiffuserConstruction(get_construction(construction_name, model))
   end  
   
   # interior sub surfaces constructions
   interior_subsurfaces = OpenStudio::Model::DefaultSubSurfaceConstructions.new(model)
   construction_set.setDefaultInteriorSubSurfaceConstructions(interior_subsurfaces)
-  if construction_name = data["interior_fixed_window"]
+  if construction_name = data['interior_fixed_window']
     interior_subsurfaces.setFixedWindowConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["interior_operable_window"]
+  if construction_name = data['interior_operable_window']
     interior_subsurfaces.setOperableWindowConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["interior_door"]
+  if construction_name = data['interior_door']
     interior_subsurfaces.setDoorConstruction(get_construction(construction_name, model))
   end  
   
   # other constructions
-  if construction_name = data["interior_partition"]
+  if construction_name = data['interior_partition']
     construction_set.setInteriorPartitionConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["space_shading"]
+  if construction_name = data['space_shading']
     construction_set.setSpaceShadingConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["building_shading"]
+  if construction_name = data['building_shading']
     construction_set.setBuildingShadingConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["site_shading"]
+  if construction_name = data['site_shading']
     construction_set.setSiteShadingConstruction(get_construction(construction_name, model))
   end
  

--- a/create_DOE_prototype_building/resources/HVACSizing.Model.rb
+++ b/create_DOE_prototype_building/resources/HVACSizing.Model.rb
@@ -45,10 +45,10 @@ class OpenStudio::Model::Model
     sim_control.setRunSimulationforWeatherFileRunPeriods(false)
     
     # Save the model to energyplus idf
-    idf_name = "sizing.idf"
-    osm_name = "sizing.osm"
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Starting sizing run here: #{sizing_run_dir}.")
-    forward_translator = OpenStudio::EnergyPlus::ForwardTranslator.new()
+    idf_name = 'sizing.idf'
+    osm_name = 'sizing.osm'
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Starting sizing run here: #{sizing_run_dir}.")
+    forward_translator = OpenStudio::EnergyPlus::ForwardTranslator.new
     idf = forward_translator.translateModel(self)
     idf_path = OpenStudio::Path.new("#{sizing_run_dir}/#{idf_name}")  
     osm_path = OpenStudio::Path.new("#{sizing_run_dir}/#{osm_name}")
@@ -64,15 +64,15 @@ class OpenStudio::Model::Model
         if File.exist?(epw_path.get.to_s)
           epw_path = epw_path.get
         else
-          OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "Model has not been assigned a weather file.")
+          OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', 'Model has not been assigned a weather file.')
           return false
         end
       else
-        OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "Model has a weather file assigned, but the file is not in the specified location.")
+        OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', 'Model has a weather file assigned, but the file is not in the specified location.')
         return false
       end
     else
-      OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "Model has not been assigned a weather file.")
+      OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', 'Model has not been assigned a weather file.')
       return false
     end
     
@@ -89,8 +89,8 @@ class OpenStudio::Model::Model
     end
 
     sql_path = nil
-    if use_runmanager == true
-      OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Running sizing run with RunManager.")
+    if use_runmanager
+      OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Running sizing run with RunManager.')
 
       # Find EnergyPlus
       require 'openstudio/energyplus/find_energyplus'
@@ -119,10 +119,10 @@ class OpenStudio::Model::Model
       
       sql_path = OpenStudio::Path.new("#{sizing_run_dir}/Energyplus/eplusout.sql")
       
-      OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Finished sizing run.")
+      OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished sizing run.')
       
     else # Use the openstudio-workflow gem
-      OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Running sizing run with openstudio-workflow gem.")
+      OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Running sizing run with openstudio-workflow gem.')
       
       # Copy the weather file to this directory
       FileUtils.copy(epw_path.to_s, sizing_run_dir)
@@ -132,7 +132,7 @@ class OpenStudio::Model::Model
       final_state = sim.run
 
       if final_state == :finished
-        OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Finished sizing run.")
+        OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished sizing run.')
       end
     
       sql_path = OpenStudio::Path.new("#{sizing_run_dir}/run/eplusout.sql")
@@ -145,7 +145,7 @@ class OpenStudio::Model::Model
       # Attach the sql file from the run to the sizing model
       self.setSqlFile(sql)
     else 
-      OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "Results for the sizing run couldn't be found here: #{sql_path}.")
+      OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', "Results for the sizing run couldn't be found here: #{sql_path}.")
       return false
     end
     
@@ -164,7 +164,7 @@ class OpenStudio::Model::Model
 
     # Ensure that the model has a sql file associated with it
     if self.sqlFile.empty?
-      OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "Failed to apply sizing values because model is missing sql file containing sizing results.")
+      OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', 'Failed to apply sizing values because model is missing sql file containing sizing results.')
       return false
     end
   
@@ -262,7 +262,7 @@ class OpenStudio::Model::Model
   # returns the autosized value as an optional double
   def getAutosizedValue(object, value_name, units)
 
-    result = OpenStudio::OptionalDouble.new()
+    result = OpenStudio::OptionalDouble.new
 
     name = object.name.get.upcase
     
@@ -290,7 +290,7 @@ class OpenStudio::Model::Model
       end
 
     else
-      OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "Model has no sql file containing results, cannot lookup data.")
+      OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', 'Model has no sql file containing results, cannot lookup data.')
     end
 
     return result

--- a/create_DOE_prototype_building/resources/Prototype.FanConstantVolume.rb
+++ b/create_DOE_prototype_building/resources/Prototype.FanConstantVolume.rb
@@ -17,7 +17,7 @@ class OpenStudio::Model::FanConstantVolume
     end
     
     # Convert max flow rate to cfm
-    maximum_flow_rate_cfm = OpenStudio.convert(maximum_flow_rate_m3_per_s, "m^3/s", "cfm").get
+    maximum_flow_rate_cfm = OpenStudio.convert(maximum_flow_rate_m3_per_s, 'm^3/s', 'cfm').get
     
     # Pressure rise will be determined based on the 
     # following logic.
@@ -49,10 +49,10 @@ class OpenStudio::Model::FanConstantVolume
     end
     
     # Set the fan pressure rise
-    pressure_rise_pa = OpenStudio.convert(pressure_rise_in_h2o, "inH_{2}O","Pa").get
+    pressure_rise_pa = OpenStudio.convert(pressure_rise_in_h2o, 'inH_{2}O','Pa').get
     self.setPressureRise(pressure_rise_pa)  
     
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.FanConstantVolume", "For Prototype: #{self.name}: #{maximum_flow_rate_cfm.round}cfm; Pressure Rise = #{pressure_rise_in_h2o}in w.c.")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.FanConstantVolume', "For Prototype: #{self.name}: #{maximum_flow_rate_cfm.round}cfm; Pressure Rise = #{pressure_rise_in_h2o}in w.c.")
     
     return true
     

--- a/create_DOE_prototype_building/resources/Prototype.FanVariableVolume.rb
+++ b/create_DOE_prototype_building/resources/Prototype.FanVariableVolume.rb
@@ -17,7 +17,7 @@ class OpenStudio::Model::FanVariableVolume
     end
     
     # Convert max flow rate to cfm
-    maximum_flow_rate_cfm = OpenStudio.convert(maximum_flow_rate_m3_per_s, "m^3/s", "cfm").get
+    maximum_flow_rate_cfm = OpenStudio.convert(maximum_flow_rate_m3_per_s, 'm^3/s', 'cfm').get
     
     # Pressure rise will be determined based on the 
     # following logic.
@@ -49,10 +49,10 @@ class OpenStudio::Model::FanVariableVolume
     end
     
     # Set the fan pressure rise
-    pressure_rise_pa = OpenStudio.convert(pressure_rise_in_h2o, "inH_{2}O","Pa").get
+    pressure_rise_pa = OpenStudio.convert(pressure_rise_in_h2o, 'inH_{2}O','Pa').get
     self.setPressureRise(pressure_rise_pa)  
     
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.FanVariableVolume", "For Prototype: #{self.name}: #{maximum_flow_rate_cfm.round}cfm; Pressure Rise = #{pressure_rise_in_h2o}in w.c.")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.FanVariableVolume', "For Prototype: #{self.name}: #{maximum_flow_rate_cfm.round}cfm; Pressure Rise = #{pressure_rise_in_h2o}in w.c.")
     
     return true
     

--- a/create_DOE_prototype_building/resources/Prototype.HeatExchangerAirToAirSensibleAndLatent.rb
+++ b/create_DOE_prototype_building/resources/Prototype.HeatExchangerAirToAirSensibleAndLatent.rb
@@ -9,7 +9,7 @@ class OpenStudio::Model::HeatExchangerAirToAirSensibleAndLatent
     
     # Get the nominal supply air flow rate
     supply_air_flow_m3_per_s = self.nominalSupplyAirFlowRate.get
-    supply_air_flow_cfm = OpenStudio.convert(supply_air_flow_m3_per_s, "m^3/s", "cfm").get
+    supply_air_flow_cfm = OpenStudio.convert(supply_air_flow_m3_per_s, 'm^3/s', 'cfm').get
     
     # Calculate the motor power for the rotatry wheel per:
     # Power (W) = (Nominal Supply Air Flow Rate (CFM) * 0.3386) + 49.5

--- a/create_DOE_prototype_building/resources/Prototype.Model.rb
+++ b/create_DOE_prototype_building/resources/Prototype.Model.rb
@@ -9,7 +9,7 @@ class OpenStudio::Model::Model
  
   def add_geometry(geometry_osm_name)
     
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Started adding geometry")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started adding geometry')
     
     # Take the existing model and remove all the objects 
     # (this is cheesy), but need to keep the same memory block
@@ -23,7 +23,7 @@ class OpenStudio::Model::Model
     # Add the objects from the geometry model to the working model
     self.addObjects(geom_model.toIdfFile.objects)
 
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Finished adding geometry")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished adding geometry')
     
     return true
     
@@ -43,7 +43,7 @@ class OpenStudio::Model::Model
         space = space.get
         space.setSpaceType(stub_space_type)
 
-        #OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Setting #{space.name} to #{building_type}.#{space_type_name}")
+        #OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Setting #{space.name} to #{building_type}.#{space_type_name}")
       end
     end
 
@@ -52,7 +52,7 @@ class OpenStudio::Model::Model
 
   def add_loads(building_vintage, climate_zone, standards_data_dir)
 
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Started applying space types (loads)")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started applying space types (loads)')
 
     path_to_standards_json = "#{standards_data_dir}/OpenStudio_Standards.json"
     path_to_master_schedules_library = "#{standards_data_dir}/Master_Schedules.osm"
@@ -72,7 +72,7 @@ class OpenStudio::Model::Model
       if stub_space_type.standardsBuildingType.is_initialized
         stds_building_type = stub_space_type.standardsBuildingType.get
       else
-        OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Space type called '#{stub_space_type.name}' has no standards building type.")
+        OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Space type called '#{stub_space_type.name}' has no standards building type.")
         return false
       end
       
@@ -81,13 +81,13 @@ class OpenStudio::Model::Model
       if stub_space_type.standardsSpaceType.is_initialized
         stds_spc_type = stub_space_type.standardsSpaceType.get
       else
-        OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Space type called '#{stub_space_type.name}' has no standards space type.")
+        OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Space type called '#{stub_space_type.name}' has no standards space type.")
         return false
       end
 
       # climate_const = space_type_generator.find_climate_zone_set(building_vintage, climate_zone, stds_building_type, stds_spc_type)
 
-      new_space_type = space_type_generator.generate_space_type(building_vintage, "ClimateZone 1-8", stds_building_type, stds_spc_type, self)[0]
+      new_space_type = space_type_generator.generate_space_type(building_vintage, 'ClimateZone 1-8', stds_building_type, stds_spc_type, self)[0]
 
       #apply the new space type to the building      
       stub_space_type.spaces.each do |space|
@@ -100,7 +100,7 @@ class OpenStudio::Model::Model
 
     end
     
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Finished applying space types (loads)")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished applying space types (loads)')
     
     return true
 
@@ -108,7 +108,7 @@ class OpenStudio::Model::Model
 
   def add_constructions(building_type, building_vintage, climate_zone, standards_data_dir)
 
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Started applying constructions")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started applying constructions')
     
     path_to_standards_json = "#{standards_data_dir}/OpenStudio_Standards.json"
     
@@ -116,19 +116,19 @@ class OpenStudio::Model::Model
     standards = {}
     temp = File.read(path_to_standards_json)
     standards = JSON.parse(temp)
-    space_types = standards["space_types"]
-    construction_sets = standards["construction_sets"]
+    space_types = standards['space_types']
+    construction_sets = standards['construction_sets']
     
     require_relative 'Standards.ConstructionSetGenerator'
     construction_set_generator = ConstructionSetGenerator.new(path_to_standards_json)
  
     # get climate zone set from specific climate zone for construction set
-    climate_zone_set = construction_set_generator.find_climate_zone_set(building_vintage, climate_zone, building_type, "")
+    climate_zone_set = construction_set_generator.find_climate_zone_set(building_vintage, climate_zone, building_type, '')
 
     # Make the default contruction set for the building
-    bldg_def_const_set = construction_set_generator.generate_construction_set(building_vintage, climate_zone_set, building_type, "", self)
+    bldg_def_const_set = construction_set_generator.generate_construction_set(building_vintage, climate_zone_set, building_type, '', self)
     if bldg_def_const_set[0].nil?
-      OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "Could not create default construction set for the building.")
+      OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', 'Could not create default construction set for the building.')
       return false
     else
       self.getBuilding.setDefaultConstructionSet(bldg_def_const_set[0])
@@ -142,7 +142,7 @@ class OpenStudio::Model::Model
       if space_type.standardsBuildingType.is_initialized
         stds_building_type = space_type.standardsBuildingType.get
       else
-        OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Space type called '#{space_type.name}' has no standards building type.")
+        OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Space type called '#{space_type.name}' has no standards building type.")
       end
       
       # Get the standards space type
@@ -150,13 +150,13 @@ class OpenStudio::Model::Model
       if space_type.standardsSpaceType.is_initialized
         stds_spc_type = space_type.standardsSpaceType.get
       else
-        OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Space type called '#{space_type.name}' has no standards space type.")
+        OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Space type called '#{space_type.name}' has no standards space type.")
       end    
     
       # If the standards space type is Attic,
       # the building type should be blank.
-      if stds_spc_type == "Attic"
-        stds_building_type = ""
+      if stds_spc_type == 'Attic'
+        stds_building_type = ''
       end
 
       climate_zone_set = construction_set_generator.find_climate_zone_set(building_vintage, climate_zone, stds_building_type, stds_spc_type)      
@@ -178,8 +178,8 @@ class OpenStudio::Model::Model
 
     # Assign a material to all internal mass objects
     material = OpenStudio::Model::StandardOpaqueMaterial.new(self)
-    material.setName("Std Wood 6inch")
-    material.setRoughness("MediumSmooth")
+    material.setName('Std Wood 6inch')
+    material.setRoughness('MediumSmooth')
     material.setThickness(0.15)
     material.setConductivity(0.12)
     material.setDensity(540)
@@ -188,7 +188,7 @@ class OpenStudio::Model::Model
     material.setSolarAbsorptance(0.7)
     material.setVisibleAbsorptance(0.7)
     construction = OpenStudio::Model::Construction.new(self)
-    construction.setName("InteriorFurnishings")
+    construction.setName('InteriorFurnishings')
     layers = OpenStudio::Model::MaterialVector.new
     layers << material
     construction.setLayers(layers)
@@ -196,7 +196,7 @@ class OpenStudio::Model::Model
       int_mass_def.setConstruction(construction)
     end
 
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Finished applying constructions")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished applying constructions')
     
     return true
 
@@ -204,7 +204,7 @@ class OpenStudio::Model::Model
 
   def create_thermal_zones
 
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Started creating thermal zones")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started creating thermal zones')
 
     # Create a thermal zone for each space in the self
     self.getSpaces.each do |space|
@@ -217,16 +217,16 @@ class OpenStudio::Model::Model
       
       # Add a thermostat
       space_type_name = space.spaceType.get.name.get
-      thermostat_name = space_type_name + " Thermostat"
+      thermostat_name = space_type_name + ' Thermostat'
       thermostat = self.getThermostatSetpointDualSetpointByName(thermostat_name)
       if thermostat.empty?
-        OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Thermostat #{thermostat_name} not found for space name: #{space.name}")
+        OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Thermostat #{thermostat_name} not found for space name: #{space.name}")
         return true
       end
       zone.setThermostatSetpointDualSetpoint(thermostat.get)
     end
 
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Finished creating thermal zones")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished creating thermal zones')
     
     return true
 
@@ -235,12 +235,12 @@ class OpenStudio::Model::Model
   def add_occupancy_sensors(building_type, building_vintage, climate_zone)
    
     # Only add occupancy sensors for 90.1-2010
-     return true unless building_vintage == "90.1-2010"
+     return true unless building_vintage == '90.1-2010'
    
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Started Adding Occupancy Sensors")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started Adding Occupancy Sensors')
 
     space_type_reduction_map = {
-      "SecondarySchool" => {"Classroom" => 0.32}
+      'SecondarySchool' => {'Classroom' => 0.32}
     }
     
     # Loop through all the space types and reduce lighting operation schedule fractions as-specified
@@ -326,13 +326,13 @@ class OpenStudio::Model::Model
         old_lights_sch_name = light.schedule.get.name.to_s
         if reduced_lights_schs[old_lights_sch_name]
           light.setSchedule(reduced_lights_schs[old_lights_sch_name])
-          OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Occupancy sensor reduction added to '#{light.name}'")
+          OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Occupancy sensor reduction added to '#{light.name}'")
         end
       end
     
     end
     
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Finished Adding Occupancy Sensors")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished Adding Occupancy Sensors')
     
     return true
     
@@ -344,13 +344,13 @@ class OpenStudio::Model::Model
     # into lookup table and implement that way instead of hard-coding as
     # inputs in the spreadsheet.
     
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Started adding exterior lights")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started adding exterior lights')
  
     # Occupancy Sensing Exterior Lights
     # which reduce to 70% power when no one is around.
-    unless prototype_input["occ_sensing_exterior_lighting_power"].nil?
-      occ_sens_ext_lts_power = prototype_input["occ_sensing_exterior_lighting_power"]
-      occ_sens_ext_lts_name = "Occ Sensing Exterior Lights"
+    unless prototype_input['occ_sensing_exterior_lighting_power'].nil?
+      occ_sens_ext_lts_power = prototype_input['occ_sensing_exterior_lighting_power']
+      occ_sens_ext_lts_name = 'Occ Sensing Exterior Lights'
       occ_sens_ext_lts_def = OpenStudio::Model::ExteriorLightsDefinition.new(self)
       occ_sens_ext_lts_def.setName("#{occ_sens_ext_lts_name} Def")
       occ_sens_ext_lts_def.setDesignLevel(occ_sens_ext_lts_power)
@@ -361,26 +361,26 @@ class OpenStudio::Model::Model
       occ_sens_ext_lts_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,24,0,0),1)
       occ_sens_ext_lts = OpenStudio::Model::ExteriorLights.new(occ_sens_ext_lts_def, occ_sens_ext_lts_sch)
       occ_sens_ext_lts.setName("#{occ_sens_ext_lts_name} Def")
-      occ_sens_ext_lts.setControlOption("AstronomicalClock")
+      occ_sens_ext_lts.setControlOption('AstronomicalClock')
     end
     
     # Building Facade and Landscape Lights
     # that don't dim at all at night.    
-    unless prototype_input["nondimming_exterior_lighting_power"].nil?
-      nondimming_ext_lts_power = prototype_input["nondimming_exterior_lighting_power"]
-      nondimming_ext_lts_name = "NonDimming Exterior Lights"
+    unless prototype_input['nondimming_exterior_lighting_power'].nil?
+      nondimming_ext_lts_power = prototype_input['nondimming_exterior_lighting_power']
+      nondimming_ext_lts_name = 'NonDimming Exterior Lights'
       nondimming_ext_lts_def = OpenStudio::Model::ExteriorLightsDefinition.new(self)
       nondimming_ext_lts_def.setName("#{nondimming_ext_lts_name} Def")
       nondimming_ext_lts_def.setDesignLevel(nondimming_ext_lts_power)
       # 
       nondimming_ext_lts_sch = nil
-      if building_vintage == "90.1-2010"
+      if building_vintage == '90.1-2010'
         nondimming_ext_lts_sch = OpenStudio::Model::ScheduleRuleset.new(self)
         nondimming_ext_lts_sch.setName("#{nondimming_ext_lts_name} Sch")
         nondimming_ext_lts_sch.defaultDaySchedule.setName("#{nondimming_ext_lts_name} Default Sch")
         nondimming_ext_lts_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,6,0,0),0)
         nondimming_ext_lts_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,24,0,0),1)
-      elsif building_vintage == "DOE Ref Pre-1980" || building_vintage == "DOE Ref 1980-2004"
+      elsif building_vintage == 'DOE Ref Pre-1980' || building_vintage == 'DOE Ref 1980-2004'
         nondimming_ext_lts_sch = self.alwaysOnDiscreteSchedule
       end
       nondimming_ext_lts = OpenStudio::Model::ExteriorLights.new(nondimming_ext_lts_def, nondimming_ext_lts_sch)
@@ -388,7 +388,7 @@ class OpenStudio::Model::Model
       nondimming_ext_lts.setControlOption("AstronomicalClock")
     end
    
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Finished adding exterior lights")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished adding exterior lights')
     
     return true
     
@@ -397,7 +397,7 @@ class OpenStudio::Model::Model
   def modify_infiltration_coefficients(building_type, building_vintage, climate_zone)
   
     # Only modify the infiltration coefficients for 90.1-2010
-    return true unless building_vintage == "90.1-2010"
+    return true unless building_vintage == '90.1-2010'
   
     # The pre-1980 and 1980-2004 buildings have this:
     # 1.0000,                  !- Constant Term Coefficient
@@ -426,7 +426,7 @@ class OpenStudio::Model::Model
     require_relative 'Prototype.FanVariableVolume'
     require_relative 'Prototype.HeatExchangerAirToAirSensibleAndLatent'
     
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Started applying prototype HVAC assumptions.")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started applying prototype HVAC assumptions.')
     
     ##### Apply equipment efficiencies
     
@@ -437,34 +437,34 @@ class OpenStudio::Model::Model
     # Heat Exchangers
     self.getHeatExchangerAirToAirSensibleAndLatents.sort.each {|obj| obj.setPrototypeNominalElectricPower}
     
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Finished applying prototype HVAC assumptions.")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished applying prototype HVAC assumptions.')
     
   end 
 
   def add_debugging_variables(type)
   
-    # "detailed"
-    # "timestep"
-    # "hourly"
-    # "daily"
-    # "monthly"
+    # 'detailed'
+    # 'timestep'
+    # 'hourly'
+    # 'daily'
+    # 'monthly'
   
     vars = []
     case type
-    when "service_water_heating"
-      var_names << ["Water Heater Water Volume Flow Rate","timestep"]
-      var_names << ["Water Use Equipment Hot Water Volume Flow Rate","timestep"]
-      var_names << ["Water Use Equipment Cold Water Volume Flow Rate","timestep"]
-      var_names << ["Water Use Equipment Hot Water Temperature","timestep"]
-      var_names << ["Water Use Equipment Cold Water Temperature","timestep"]
-      var_names << ["Water Use Equipment Mains Water Volume","timestep"]
-      var_names << ["Water Use Equipment Target Water Temperature","timestep"]
-      var_names << ["Water Use Equipment Mixed Water Temperature","timestep"]
-      var_names << ["Water Heater Tank Temperature","timestep"]
-      var_names << ["Water Heater Use Side Mass Flow Rate","timestep"]
-      var_names << ["Water Heater Heating Rate","timestep"]
-      var_names << ["Water Heater Water Volume Flow Rate","timestep"]
-      var_names << ["Water Heater Water Volume","timestep"]
+    when 'service_water_heating'
+      var_names << ['Water Heater Water Volume Flow Rate','timestep']
+      var_names << ['Water Use Equipment Hot Water Volume Flow Rate','timestep']
+      var_names << ['Water Use Equipment Cold Water Volume Flow Rate','timestep']
+      var_names << ['Water Use Equipment Hot Water Temperature','timestep']
+      var_names << ['Water Use Equipment Cold Water Temperature','timestep']
+      var_names << ['Water Use Equipment Mains Water Volume','timestep']
+      var_names << ['Water Use Equipment Target Water Temperature','timestep']
+      var_names << ['Water Use Equipment Mixed Water Temperature','timestep']
+      var_names << ['Water Heater Tank Temperature','timestep']
+      var_names << ['Water Heater Use Side Mass Flow Rate','timestep']
+      var_names << ['Water Heater Heating Rate','timestep']
+      var_names << ['Water Heater Water Volume Flow Rate','timestep']
+      var_names << ['Water Heater Water Volume','timestep']
     end
   
     var_names.each do |var_name, reporting_frequency|
@@ -485,7 +485,7 @@ class OpenStudio::Model::Model
       Dir.mkdir(run_dir)
     end
     
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Started simulation in '#{run_dir}'")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Started simulation in '#{run_dir}'")
     
     # Change the simulation to only run the weather file
     # and not run the sizing day simulations
@@ -494,9 +494,9 @@ class OpenStudio::Model::Model
     sim_control.setRunSimulationforWeatherFileRunPeriods(true)
     
     # Save the model to energyplus idf
-    idf_name = "in.idf"
-    osm_name = "in.osm"
-    forward_translator = OpenStudio::EnergyPlus::ForwardTranslator.new()
+    idf_name = 'in.idf'
+    osm_name = 'in.osm'
+    forward_translator = OpenStudio::EnergyPlus::ForwardTranslator.new
     idf = forward_translator.translateModel(self)
     idf_path = OpenStudio::Path.new("#{run_dir}/#{idf_name}")  
     osm_path = OpenStudio::Path.new("#{run_dir}/#{osm_name}")
@@ -512,15 +512,15 @@ class OpenStudio::Model::Model
         if File.exist?(epw_path.get.to_s)
           epw_path = epw_path.get
         else
-          OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "Model has not been assigned a weather file.")
+          OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', 'Model has not been assigned a weather file.')
           return false
         end
       else
-        OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "Model has a weather file assigned, but the file is not in the specified location.")
+        OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', 'Model has a weather file assigned, but the file is not in the specified location.')
         return false
       end
     else
-      OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "Model has not been assigned a weather file.")
+      OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', 'Model has not been assigned a weather file.')
       return false
     end
     
@@ -556,11 +556,11 @@ class OpenStudio::Model::Model
       # Attach the sql file from the run to the sizing model
       self.setSqlFile(sql)
     else 
-      OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "Results for the sizing run couldn't be found here: #{sql_path}.")
+      OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', "Results for the sizing run couldn't be found here: #{sql_path}.")
       return false
     end
     
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Finished simulation in '#{run_dir}'")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Finished simulation in '#{run_dir}'")
     
     return true
 
@@ -575,15 +575,15 @@ class OpenStudio::Model::Model
     # "monthly"
    
     vars = []
-    vars << ["Heating Coil Gas Rate", "detailed"]
-    vars << ["Zone Thermostat Air Temperature", "detailed"]
-    vars << ["Zone Thermostat Heating Setpoint Temperature", "detailed"]
-    vars << ["Zone Thermostat Cooling Setpoint Temperature", "detailed"]
-    vars << ["Zone Air System Sensible Heating Rate", "detailed"]
-    vars << ["Zone Air System Sensible Cooling Rate", "detailed"]
-    vars << ["Fan Electric Power", "detailed"]
-    vars << ["Zone Mechanical Ventilation Standard Density Volume Flow Rate", "detailed"]
-    vars << ["Air System Outdoor Air Mass Flow Rate", "detailed"]
+    vars << ['Heating Coil Gas Rate', 'detailed']
+    vars << ['Zone Thermostat Air Temperature', 'detailed']
+    vars << ['Zone Thermostat Heating Setpoint Temperature', 'detailed']
+    vars << ['Zone Thermostat Cooling Setpoint Temperature', 'detailed']
+    vars << ['Zone Air System Sensible Heating Rate', 'detailed']
+    vars << ['Zone Air System Sensible Cooling Rate', 'detailed']
+    vars << ['Fan Electric Power', 'detailed']
+    vars << ['Zone Mechanical Ventilation Standard Density Volume Flow Rate', 'detailed']
+    vars << ['Air System Outdoor Air Mass Flow Rate', 'detailed']
     
     vars.each do |var, freq|  
       outputVariable = OpenStudio::Model::OutputVariable.new(var, self)
@@ -597,7 +597,7 @@ class OpenStudio::Model::Model
     require 'date'
 
     # First, find all the schedules that match the name
-    rules = find_objects(schedules, {"name"=>schedule_name})
+    rules = find_objects(schedules, {'name'=>schedule_name})
     
     # Make a schedule ruleset
     sch_ruleset = OpenStudio::Model::ScheduleRuleset.new(self)
@@ -605,14 +605,14 @@ class OpenStudio::Model::Model
 
     # Loop through the rules, making one for each row in the spreadsheet
     rules.each do |rule|
-      day_types = rule["day_types"]
-      start_date = DateTime.parse(rule["start_date"])
-      end_date = DateTime.parse(rule["end_date"])
+      day_types = rule['day_types']
+      start_date = DateTime.parse(rule['start_date'])
+      end_date = DateTime.parse(rule['end_date'])
       
       #Day Type choices: Wkdy, Wknd, Mon, Tue, Wed, Thu, Fri, Sat, Sun, WntrDsn, SmrDsn, Hol
       
       # Default
-      if day_types.include?("Default")
+      if day_types.include?('Default')
         day_sch = sch_ruleset.defaultDaySchedule
         day_sch.setName("#{schedule_name} Default")
         for i in 1..24
@@ -622,7 +622,7 @@ class OpenStudio::Model::Model
       end
       
       # Winter Design Day
-      if day_types.include?("WntrDsn")
+      if day_types.include?('WntrDsn')
         day_sch = OpenStudio::Model::ScheduleDay.new(self)  
         sch_ruleset.setWinterDesignDaySchedule(day_sch)
         day_sch = sch_ruleset.winterDesignDaySchedule
@@ -634,7 +634,7 @@ class OpenStudio::Model::Model
       end    
       
       # Summer Design Day
-      if day_types.include?("SmrDsn")
+      if day_types.include?('SmrDsn')
         day_sch = OpenStudio::Model::ScheduleDay.new(self)  
         sch_ruleset.setSummerDesignDaySchedule(day_sch)
         day_sch = sch_ruleset.summerDesignDaySchedule
@@ -646,15 +646,15 @@ class OpenStudio::Model::Model
       end
       
       # Other days (weekdays, weekends, etc)
-      if day_types.include?("Wknd") ||
-        day_types.include?("Wkdy") ||
-        day_types.include?("Sat") ||
-        day_types.include?("Sun") ||
-        day_types.include?("Mon") ||
-        day_types.include?("Tue") ||
-        day_types.include?("Wed") ||
-        day_types.include?("Thu") ||
-        day_types.include?("Fri")
+      if day_types.include?('Wknd') ||
+        day_types.include?('Wkdy') ||
+        day_types.include?('Sat') ||
+        day_types.include?('Sun') ||
+        day_types.include?('Mon') ||
+        day_types.include?('Tue') ||
+        day_types.include?('Wed') ||
+        day_types.include?('Thu') ||
+        day_types.include?('Fri')
       
         # Make the Rule
         sch_rule = OpenStudio::Model::ScheduleRule.new(sch_ruleset)
@@ -671,12 +671,12 @@ class OpenStudio::Model::Model
         
         # Set the days when the rule applies
         # Weekends
-        if day_types.include?("Wknd")
+        if day_types.include?('Wknd')
           sch_rule.setApplySaturday(true)
           sch_rule.setApplySunday(true)
         end
         # Weekdays
-        if day_types.include?("Wkdy")
+        if day_types.include?('Wkdy')
           sch_rule.setApplyMonday(true)
           sch_rule.setApplyTuesday(true)
           sch_rule.setApplyWednesday(true)
@@ -684,13 +684,13 @@ class OpenStudio::Model::Model
           sch_rule.setApplyFriday(true)
         end
         # Individual Days
-        sch_rule.setApplyMonday(true) if day_types.include?("Mon")     
-        sch_rule.setApplyTuesday(true) if day_types.include?("Tue")
-        sch_rule.setApplyWednesday(true) if day_types.include?("Wed")
-        sch_rule.setApplyThursday(true) if day_types.include?("Thu")
-        sch_rule.setApplyFriday(true) if day_types.include?("Fri")
-        sch_rule.setApplySaturday(true) if day_types.include?("Sat")        
-        sch_rule.setApplySunday(true) if day_types.include?("Sun")
+        sch_rule.setApplyMonday(true) if day_types.include?('Mon')
+        sch_rule.setApplyTuesday(true) if day_types.include?('Tue')
+        sch_rule.setApplyWednesday(true) if day_types.include?('Wed')
+        sch_rule.setApplyThursday(true) if day_types.include?('Thu')
+        sch_rule.setApplyFriday(true) if day_types.include?('Fri')
+        sch_rule.setApplySaturday(true) if day_types.include?('Sat')
+        sch_rule.setApplySunday(true) if day_types.include?('Sun')
 
       end
       

--- a/create_DOE_prototype_building/resources/Prototype.Model.rb
+++ b/create_DOE_prototype_building/resources/Prototype.Model.rb
@@ -385,7 +385,7 @@ class OpenStudio::Model::Model
       end
       nondimming_ext_lts = OpenStudio::Model::ExteriorLights.new(nondimming_ext_lts_def, nondimming_ext_lts_sch)
       nondimming_ext_lts.setName("#{nondimming_ext_lts_name} Def")
-      nondimming_ext_lts.setControlOption("AstronomicalClock")
+      nondimming_ext_lts.setControlOption('AstronomicalClock')
     end
    
     OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished adding exterior lights')
@@ -498,7 +498,7 @@ class OpenStudio::Model::Model
     osm_name = 'in.osm'
     forward_translator = OpenStudio::EnergyPlus::ForwardTranslator.new
     idf = forward_translator.translateModel(self)
-    idf_path = OpenStudio::Path.new("#{run_dir}/#{idf_name}")  
+    idf_path = OpenStudio::Path.new("#{run_dir}/#{idf_name}")
     osm_path = OpenStudio::Path.new("#{run_dir}/#{osm_name}")
     idf.save(idf_path,true)
     self.save(osm_path,true)

--- a/create_DOE_prototype_building/resources/Prototype.hvac_systems.rb
+++ b/create_DOE_prototype_building/resources/Prototype.hvac_systems.rb
@@ -146,15 +146,9 @@ class OpenStudio::Model::Model
     
     # Find the initial Chiller properties based on initial inputs
     search_criteria = {
-<<<<<<< HEAD
       'cooling_type' => prototype_input['chiller_cooling_type'],
       'condenser_type' => prototype_input['chiller_condenser_type'],
       'compressor_type' => prototype_input['chiller_compressor_type'],
-=======
-      "cooling_type" => prototype_input["chiller_cooling_type"],
-      "condenser_type" => prototype_input["chiller_condenser_type"],
-      "compressor_type" => prototype_input["chiller_compressor_type"],
->>>>>>> master
     }
     
     chiller_properties = find_object(chillers, search_criteria, prototype_input['chiller_capacity_guess'])

--- a/create_DOE_prototype_building/resources/Prototype.hvac_systems.rb
+++ b/create_DOE_prototype_building/resources/Prototype.hvac_systems.rb
@@ -6,29 +6,29 @@ class OpenStudio::Model::Model
 
     #hot water loop
     hot_water_loop = OpenStudio::Model::PlantLoop.new(self)
-    hot_water_loop.setName("Hot Water Loop")
+    hot_water_loop.setName('Hot Water Loop')
 
     #hot water loop controls
     hw_temp_f = 180 #HW setpoint 180F 
     hw_delta_t_r = 20 #20F delta-T    
-    hw_temp_c = OpenStudio.convert(hw_temp_f,"F","C").get
-    hw_delta_t_k = OpenStudio.convert(hw_delta_t_r,"R","K").get
+    hw_temp_c = OpenStudio.convert(hw_temp_f,'F','C').get
+    hw_delta_t_k = OpenStudio.convert(hw_delta_t_r,'R','K').get
     hw_temp_sch = OpenStudio::Model::ScheduleRuleset.new(self)
     hw_temp_sch.setName("Hot Water Loop Temp - #{hw_temp_f}F")
-    hw_temp_sch.defaultDaySchedule().setName("Hot Water Loop Temp - #{hw_temp_f}F Default")
-    hw_temp_sch.defaultDaySchedule().addValue(OpenStudio::Time.new(0,24,0,0),hw_temp_c)
+    hw_temp_sch.defaultDaySchedule.setName("Hot Water Loop Temp - #{hw_temp_f}F Default")
+    hw_temp_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,24,0,0),hw_temp_c)
     hw_stpt_manager = OpenStudio::Model::SetpointManagerScheduled.new(self,hw_temp_sch)    
     hw_stpt_manager.addToNode(hot_water_loop.supplyOutletNode)
     sizing_plant = hot_water_loop.sizingPlant
-    sizing_plant.setLoopType("Heating")
+    sizing_plant.setLoopType('Heating')
     sizing_plant.setDesignLoopExitTemperature(hw_temp_c)
     sizing_plant.setLoopDesignTemperatureDifference(hw_delta_t_k)         
     
     #hot water pump
     hw_pump = OpenStudio::Model::PumpVariableSpeed.new(self)
-    hw_pump.setName("Hot Water Loop Pump")
+    hw_pump.setName('Hot Water Loop Pump')
     hw_pump_head_ft_h2o = 60.0
-    hw_pump_head_press_pa = OpenStudio.convert(hw_pump_head_ft_h2o, "ftH_{2}O","Pa").get
+    hw_pump_head_press_pa = OpenStudio.convert(hw_pump_head_ft_h2o, 'ftH_{2}O','Pa').get
     hw_pump.setRatedPumpHead(hw_pump_head_press_pa)
     hw_pump.setMotorEfficiency(0.9)
     hw_pump.setFractionofMotorInefficienciestoFluidStream(0)
@@ -36,16 +36,16 @@ class OpenStudio::Model::Model
     hw_pump.setCoefficient2ofthePartLoadPerformanceCurve(1)
     hw_pump.setCoefficient3ofthePartLoadPerformanceCurve(0)
     hw_pump.setCoefficient4ofthePartLoadPerformanceCurve(0)
-    hw_pump.setPumpControlType("Intermittent")
+    hw_pump.setPumpControlType('Intermittent')
     hw_pump.addToNode(hot_water_loop.supplyInletNode)
     
     #boiler
     boiler = OpenStudio::Model::BoilerHotWater.new(self)
-    boiler.setName("Hot Water Loop Boiler")
-    boiler.setFuelType("NaturalGas")
+    boiler.setName('Hot Water Loop Boiler')
+    boiler.setFuelType('NaturalGas')
     boiler.setDesignWaterOutletTemperature(hw_temp_c)
     boiler.setNominalThermalEfficiency(0.78)
-    boiler.setBoilerFlowMode("LeavingSetpointModulated")
+    boiler.setBoilerFlowMode('LeavingSetpointModulated')
     hot_water_loop.addSupplyBranchForComponent(boiler)   
     
     #hot water loop pipes
@@ -66,37 +66,37 @@ class OpenStudio::Model::Model
 
   def add_chw_loop(prototype_input, hvac_standards)
     
-    chillers = hvac_standards["chillers"]
+    chillers = hvac_standards['chillers']
     
     # Chilled water loop
     chilled_water_loop = OpenStudio::Model::PlantLoop.new(self)
-    chilled_water_loop.setName("Chilled Water Loop")
+    chilled_water_loop.setName('Chilled Water Loop')
 
     # Chilled water loop controls
     chw_temp_f = 44 #CHW setpoint 44F 
     chw_delta_t_r = 12 #12F delta-T    
-    chw_temp_c = OpenStudio.convert(chw_temp_f,"F","C").get
-    chw_delta_t_k = OpenStudio.convert(chw_delta_t_r,"R","K").get
+    chw_temp_c = OpenStudio.convert(chw_temp_f,'F','C').get
+    chw_delta_t_k = OpenStudio.convert(chw_delta_t_r,'R','K').get
     chw_temp_sch = OpenStudio::Model::ScheduleRuleset.new(self)
     chw_temp_sch.setName("Chilled Water Loop Temp - #{chw_temp_f}F")
-    chw_temp_sch.defaultDaySchedule().setName("Chilled Water Loop Temp - #{chw_temp_f}F Default")
-    chw_temp_sch.defaultDaySchedule().addValue(OpenStudio::Time.new(0,24,0,0),chw_temp_c)
+    chw_temp_sch.defaultDaySchedule.setName("Chilled Water Loop Temp - #{chw_temp_f}F Default")
+    chw_temp_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,24,0,0),chw_temp_c)
     chw_stpt_manager = OpenStudio::Model::SetpointManagerScheduled.new(self,chw_temp_sch)    
     chw_stpt_manager.addToNode(chilled_water_loop.supplyOutletNode)
     sizing_plant = chilled_water_loop.sizingPlant
-    sizing_plant.setLoopType("Cooling")
+    sizing_plant.setLoopType('Cooling')
     sizing_plant.setDesignLoopExitTemperature(chw_temp_c)
     sizing_plant.setLoopDesignTemperatureDifference(chw_delta_t_k)         
     
-    puts prototype_input["chw_pumping_type"]
+    puts prototype_input['chw_pumping_type']
     
     # Chilled water pumps
-    if prototype_input["chw_pumping_type"] == "const_pri"
+    if prototype_input['chw_pumping_type'] == 'const_pri'
       # Primary chilled water pump
       pri_chw_pump = OpenStudio::Model::PumpVariableSpeed.new(self)
-      pri_chw_pump.setName("Chilled Water Loop Pump")
+      pri_chw_pump.setName('Chilled Water Loop Pump')
       pri_chw_pump_head_ft_h2o = 60.0
-      pri_chw_pump_head_press_pa = OpenStudio.convert(pri_chw_pump_head_ft_h2o, "ftH_{2}O","Pa").get
+      pri_chw_pump_head_press_pa = OpenStudio.convert(pri_chw_pump_head_ft_h2o, 'ftH_{2}O','Pa').get
       pri_chw_pump.setRatedPumpHead(pri_chw_pump_head_press_pa)
       pri_chw_pump.setMotorEfficiency(0.9)
       # Flat pump curve makes it behave as a constant speed pump
@@ -105,14 +105,14 @@ class OpenStudio::Model::Model
       pri_chw_pump.setCoefficient2ofthePartLoadPerformanceCurve(1)
       pri_chw_pump.setCoefficient3ofthePartLoadPerformanceCurve(0)
       pri_chw_pump.setCoefficient4ofthePartLoadPerformanceCurve(0)
-      pri_chw_pump.setPumpControlType("Intermittent")
+      pri_chw_pump.setPumpControlType('Intermittent')
       pri_chw_pump.addToNode(chilled_water_loop.supplyInletNode)   
-    elsif prototype_input["chw_pumping_type"] == "const_pri_var_sec" 
+    elsif prototype_input['chw_pumping_type'] == 'const_pri_var_sec'
       # Primary chilled water pump
       pri_chw_pump = OpenStudio::Model::PumpVariableSpeed.new(self)
-      pri_chw_pump.setName("Chilled Water Loop Primary Pump")
+      pri_chw_pump.setName('Chilled Water Loop Primary Pump')
       pri_chw_pump_head_ft_h2o = 15
-      pri_chw_pump_head_press_pa = OpenStudio.convert(pri_chw_pump_head_ft_h2o, "ftH_{2}O","Pa").get
+      pri_chw_pump_head_press_pa = OpenStudio.convert(pri_chw_pump_head_ft_h2o, 'ftH_{2}O','Pa').get
       pri_chw_pump.setRatedPumpHead(pri_chw_pump_head_press_pa)
       pri_chw_pump.setMotorEfficiency(0.9)
       # Flat pump curve makes it behave as a constant speed pump
@@ -121,13 +121,13 @@ class OpenStudio::Model::Model
       pri_chw_pump.setCoefficient2ofthePartLoadPerformanceCurve(1)
       pri_chw_pump.setCoefficient3ofthePartLoadPerformanceCurve(0)
       pri_chw_pump.setCoefficient4ofthePartLoadPerformanceCurve(0)    
-      pri_chw_pump.setPumpControlType("Intermittent")
+      pri_chw_pump.setPumpControlType('Intermittent')
       pri_chw_pump.addToNode(chilled_water_loop.supplyInletNode) 
       # Secondary chilled water pump
       sec_chw_pump = OpenStudio::Model::PumpVariableSpeed.new(self)
-      sec_chw_pump.setName("Chilled Water Loop Secondary Pump")
+      sec_chw_pump.setName('Chilled Water Loop Secondary Pump')
       sec_chw_pump_head_ft_h2o = 45
-      sec_chw_pump_head_press_pa = OpenStudio.convert(sec_chw_pump_head_ft_h2o, "ftH_{2}O","Pa").get
+      sec_chw_pump_head_press_pa = OpenStudio.convert(sec_chw_pump_head_ft_h2o, 'ftH_{2}O','Pa').get
       sec_chw_pump.setRatedPumpHead(sec_chw_pump_head_press_pa)
       sec_chw_pump.setMotorEfficiency(0.9)
       # Curve makes it perform like variable speed pump
@@ -136,36 +136,36 @@ class OpenStudio::Model::Model
       sec_chw_pump.setCoefficient2ofthePartLoadPerformanceCurve(0.0205)
       sec_chw_pump.setCoefficient3ofthePartLoadPerformanceCurve(0.4101)
       sec_chw_pump.setCoefficient4ofthePartLoadPerformanceCurve(0.5753)    
-      sec_chw_pump.setPumpControlType("Intermittent")
+      sec_chw_pump.setPumpControlType('Intermittent')
       sec_chw_pump.addToNode(chilled_water_loop.demandInletNode) 
       # Change the chilled water loop to have a two-way common pipes
-      chilled_water_loop.setCommonPipeSimulation("CommonPipe")
+      chilled_water_loop.setCommonPipeSimulation('CommonPipe')
     else
       
     end
     
     # Find the initial Chiller properties based on initial inputs
     search_criteria = {
-      "cooling_type" => prototype_input["chiller_cooling_type"],
-      "condenser_type" => prototype_input["chller_condenser_type"],
-      "compressor_type" => prototype_input["chiller_compressor_type"],
+      'cooling_type' => prototype_input['chiller_cooling_type'],
+      'condenser_type' => prototype_input['chiller_condenser_type'],
+      'compressor_type' => prototype_input['chiller_compressor_type'],
     }
     
-    chiller_properties = find_object(chillers, search_criteria, prototype_input["chiller_capacity_guess"])
+    chiller_properties = find_object(chillers, search_criteria, prototype_input['chiller_capacity_guess'])
     
     # Make the correct type of chiller based these properties
     chiller = add_chiller(hvac_standards, chiller_properties)
     chiller.setReferenceLeavingChilledWaterTemperature(chw_temp_c)
     ref_cond_wtr_temp_f = 95
-    ref_cond_wtr_temp_c = OpenStudio.convert(ref_cond_wtr_temp_f,"F","C").get
+    ref_cond_wtr_temp_c = OpenStudio.convert(ref_cond_wtr_temp_f,'F','C').get
     chiller.setReferenceEnteringCondenserFluidTemperature(ref_cond_wtr_temp_c)
     chiller.setMinimumPartLoadRatio(0.15)
     chiller.setMaximumPartLoadRatio(1.0)
     chiller.setOptimumPartLoadRatio(0.8)
     chiller.setMinimumUnloadingRatio(0.15)
-    chiller.setCondenserType("AirCooled")
-    chiller.setLeavingChilledWaterLowerTemperatureLimit(OpenStudio.convert(36,"F","C").get)
-    chiller.setChillerFlowMode("VariableFlow")
+    chiller.setCondenserType('AirCooled')
+    chiller.setLeavingChilledWaterLowerTemperatureLimit(OpenStudio.convert(36,'F','C').get)
+    chiller.setChillerFlowMode('VariableFlow')
     chilled_water_loop.addSupplyBranchForComponent(chiller)  
     
     #chilled water loop pipes
@@ -188,8 +188,8 @@ class OpenStudio::Model::Model
 
     hw_temp_f = 180 #HW setpoint 180F 
     hw_delta_t_r = 20 #20F delta-T    
-    hw_temp_c = OpenStudio.convert(hw_temp_f,"F","C").get
-    hw_delta_t_k = OpenStudio.convert(hw_delta_t_r,"R","K").get
+    hw_temp_c = OpenStudio.convert(hw_temp_f,'F','C').get
+    hw_delta_t_k = OpenStudio.convert(hw_delta_t_r,'R','K').get
 
     #hvac operation schedule
     # HVACOperationSchd,On/Off,
@@ -199,28 +199,28 @@ class OpenStudio::Model::Model
     # For: AllOtherDays,Until: 24:00,0.0    
     #weekdays and summer design days
     hvac_op_sch = OpenStudio::Model::ScheduleRuleset.new(self)
-    hvac_op_sch.setName("HVAC Operation Schedule")
-    hvac_op_sch.defaultDaySchedule.setName("HVAC Operation Schedule Weekdays") 
+    hvac_op_sch.setName('HVAC Operation Schedule')
+    hvac_op_sch.defaultDaySchedule.setName('HVAC Operation Schedule Weekdays')
     hvac_op_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,6,0,0), 0.0)
     hvac_op_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,22,0,0), 1.0)
     hvac_op_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,24,0,0), 0.0)
     hvac_op_sch.setSummerDesignDaySchedule(hvac_op_sch.defaultDaySchedule)
     #saturdays and winter design days
     saturday_rule = OpenStudio::Model::ScheduleRule.new(hvac_op_sch)
-    saturday_rule.setName("HVAC Operation Schedule Saturday Rule")
+    saturday_rule.setName('HVAC Operation Schedule Saturday Rule')
     saturday_rule.setApplySaturday(true)   
     saturday = saturday_rule.daySchedule  
-    saturday.setName("HVAC Operation Schedule Saturday")
+    saturday.setName('HVAC Operation Schedule Saturday')
     saturday.addValue(OpenStudio::Time.new(0,6,0,0), 0.0)
     saturday.addValue(OpenStudio::Time.new(0,18,0,0), 1.0)
     saturday.addValue(OpenStudio::Time.new(0,24,0,0), 0.0)
     hvac_op_sch.setWinterDesignDaySchedule(saturday)
     #sundays
     sunday_rule = OpenStudio::Model::ScheduleRule.new(hvac_op_sch)
-    sunday_rule.setName("HVAC Operation Schedule Sunday Rule")
+    sunday_rule.setName('HVAC Operation Schedule Sunday Rule')
     sunday_rule.setApplySunday(true)   
     sunday = sunday_rule.daySchedule  
-    sunday.setName("HVAC Operation Schedule Sunday")
+    sunday.setName('HVAC Operation Schedule Sunday')
     sunday.addValue(OpenStudio::Time.new(0,24,0,0), 0.0)
     
     #motorized oa damper schedule
@@ -231,28 +231,28 @@ class OpenStudio::Model::Model
     # For: AllOtherDays,Until: 24:00,0.0
     #weekdays and summer design days
     motorized_oa_damper_sch = OpenStudio::Model::ScheduleRuleset.new(self)
-    motorized_oa_damper_sch.setName("Motorized OA Damper Schedule")
-    motorized_oa_damper_sch.defaultDaySchedule.setName("Motorized OA Damper Schedule Weekdays") 
+    motorized_oa_damper_sch.setName('Motorized OA Damper Schedule')
+    motorized_oa_damper_sch.defaultDaySchedule.setName('Motorized OA Damper Schedule Weekdays')
     motorized_oa_damper_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,7,0,0), 0.0)
     motorized_oa_damper_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,22,0,0), 1.0)
     motorized_oa_damper_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,24,0,0), 0.0)
     motorized_oa_damper_sch.setSummerDesignDaySchedule(motorized_oa_damper_sch.defaultDaySchedule)
     #saturdays and winter design days
     saturday_rule = OpenStudio::Model::ScheduleRule.new(motorized_oa_damper_sch)
-    saturday_rule.setName("Motorized OA Damper Schedule Saturday Rule")
+    saturday_rule.setName('Motorized OA Damper Schedule Saturday Rule')
     saturday_rule.setApplySaturday(true)   
     saturday = saturday_rule.daySchedule  
-    saturday.setName("Motorized OA Damper Schedule Saturday")
+    saturday.setName('Motorized OA Damper Schedule Saturday')
     saturday.addValue(OpenStudio::Time.new(0,7,0,0), 0.0)
     saturday.addValue(OpenStudio::Time.new(0,18,0,0), 1.0)
     saturday.addValue(OpenStudio::Time.new(0,24,0,0), 0.0)
     motorized_oa_damper_sch.setWinterDesignDaySchedule(saturday)
     #sundays
     sunday_rule = OpenStudio::Model::ScheduleRule.new(motorized_oa_damper_sch)
-    sunday_rule.setName("Motorized OA Damper Schedule Sunday Rule")
+    sunday_rule.setName('Motorized OA Damper Schedule Sunday Rule')
     sunday_rule.setApplySunday(true)   
     sunday = sunday_rule.daySchedule  
-    sunday.setName("Motorized OA Damper Schedule Sunday")
+    sunday.setName('Motorized OA Damper Schedule Sunday')
     sunday.addValue(OpenStudio::Time.new(0,24,0,0), 0.0)    
     
     #control temps used across all air handlers
@@ -261,15 +261,15 @@ class OpenStudio::Model::Model
     htg_sa_temp_f = 55 # Central deck htg temp 55F
     rht_sa_temp_f = 104 # VAV box reheat to 104F
     
-    clg_sa_temp_c = OpenStudio.convert(clg_sa_temp_f,"F","C").get
-    prehtg_sa_temp_c = OpenStudio.convert(prehtg_sa_temp_f,"F","C").get
-    htg_sa_temp_c = OpenStudio.convert(htg_sa_temp_f,"F","C").get
-    rht_sa_temp_c = OpenStudio.convert(rht_sa_temp_f,"F","C").get
+    clg_sa_temp_c = OpenStudio.convert(clg_sa_temp_f,'F','C').get
+    prehtg_sa_temp_c = OpenStudio.convert(prehtg_sa_temp_f,'F','C').get
+    htg_sa_temp_c = OpenStudio.convert(htg_sa_temp_f,'F','C').get
+    rht_sa_temp_c = OpenStudio.convert(rht_sa_temp_f,'F','C').get
     
     sa_temp_sch = OpenStudio::Model::ScheduleRuleset.new(self)
     sa_temp_sch.setName("Supply Air Temp - #{clg_sa_temp_f}F")
-    sa_temp_sch.defaultDaySchedule().setName("Supply Air Temp - #{clg_sa_temp_f}F Default")
-    sa_temp_sch.defaultDaySchedule().addValue(OpenStudio::Time.new(0,24,0,0),clg_sa_temp_c)
+    sa_temp_sch.defaultDaySchedule.setName("Supply Air Temp - #{clg_sa_temp_f}F Default")
+    sa_temp_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,24,0,0),clg_sa_temp_c)
 
     #air handler
     air_loop = OpenStudio::Model::AirLoopHVAC.new(self)
@@ -279,12 +279,12 @@ class OpenStudio::Model::Model
     #air handler controls
     hw_stpt_manager = OpenStudio::Model::SetpointManagerScheduled.new(self,sa_temp_sch)    
     hw_stpt_manager.addToNode(air_loop.supplyOutletNode)
-    sizing_system = air_loop.sizingSystem()
-    sizing_system.setSizingOption("Coincident")
+    sizing_system = air_loop.sizingSystem
+    sizing_system.setSizingOption('Coincident')
     sizing_system.setAllOutdoorAirinCooling(false)
     sizing_system.setAllOutdoorAirinHeating(false)
-    sizing_system.setSystemOutdoorAirMethod("VentilationRateProcedure")
-    air_loop.setNightCycleControlType("CyleOnAny")
+    sizing_system.setSystemOutdoorAirMethod('VentilationRateProcedure')
+    air_loop.setNightCycleControlType('CycleOnAny')
     
     #fan
     fan = OpenStudio::Model::FanVariableVolume.new(self,self.alwaysOnDiscreteSchedule)
@@ -292,7 +292,7 @@ class OpenStudio::Model::Model
     fan.setFanEfficiency(0.6045)
     fan.setMotorEfficiency(0.93)
     fan_static_pressure_in_h2o = 5.58
-    fan_static_pressure_pa = OpenStudio.convert(fan_static_pressure_in_h2o, "inH_{2}O","Pa").get
+    fan_static_pressure_pa = OpenStudio.convert(fan_static_pressure_in_h2o, 'inH_{2}O','Pa').get
     fan.setPressureRise(fan_static_pressure_pa)
     fan.addToNode(air_loop.supplyInletNode)
     
@@ -316,15 +316,15 @@ class OpenStudio::Model::Model
     oa_intake_controller = OpenStudio::Model::ControllerOutdoorAir.new(self)
     oa_intake = OpenStudio::Model::AirLoopHVACOutdoorAirSystem.new(self, oa_intake_controller)    
     oa_intake.setName("#{thermal_zones.size} Zone VAV OA Sys")
-    oa_intake_controller.setEconomizerControlType("NoEconomizer")
-    oa_intake_controller.setMinimumLimitType("FixedMinimum")
+    oa_intake_controller.setEconomizerControlType('NoEconomizer')
+    oa_intake_controller.setMinimumLimitType('FixedMinimum')
     oa_intake_controller.setMinimumOutdoorAirSchedule(motorized_oa_damper_sch)
     oa_intake.addToNode(air_loop.supplyInletNode)
 
     #heat exchanger on oa system
     heat_exchanger = OpenStudio::Model::HeatExchangerAirToAirSensibleAndLatent.new(self)
     heat_exchanger.setName("#{thermal_zones.size} Zone VAV HX")
-    heat_exchanger.setHeatExchangerType("Rotary")
+    heat_exchanger.setHeatExchangerType('Rotary')
     heat_exchanger.setSensibleEffectivenessat100CoolingAirFlow(0.7)
     heat_exchanger.setSensibleEffectivenessat75CoolingAirFlow(0.6)
     heat_exchanger.setLatentEffectivenessat100CoolingAirFlow(0.7)
@@ -341,7 +341,7 @@ class OpenStudio::Model::Model
     if oa_node.is_initialized
       heat_exchanger.addToNode(oa_node.get)
     else
-      OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "No outdoor air node found, can not add heat exchanger")
+      OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', 'No outdoor air node found, can not add heat exchanger')
       return false
     end
     
@@ -360,9 +360,9 @@ class OpenStudio::Model::Model
       #vav terminal
       terminal = OpenStudio::Model::AirTerminalSingleDuctVAVReheat.new(self,self.alwaysOnDiscreteSchedule,rht_coil)
       terminal.setName("#{zone.name} VAV Term")
-      terminal.setZoneMinimumAirFlowMethod("Constant")
+      terminal.setZoneMinimumAirFlowMethod('Constant')
       terminal.setConstantMinimumAirFlowFraction(0.3)
-      terminal.setDamperHeatingAction("Normal")
+      terminal.setDamperHeatingAction('Normal')
       air_loop.addBranchForZone(zone,terminal.to_StraightComponent)
     
     end
@@ -381,28 +381,28 @@ class OpenStudio::Model::Model
     # For: AllOtherDays,Until: 24:00,0.0    
     #weekdays and summer design days
     hvac_op_sch = OpenStudio::Model::ScheduleRuleset.new(self)
-    hvac_op_sch.setName("HVAC Operation Schedule")
-    hvac_op_sch.defaultDaySchedule.setName("HVAC Operation Schedule Weekdays") 
+    hvac_op_sch.setName('HVAC Operation Schedule')
+    hvac_op_sch.defaultDaySchedule.setName('HVAC Operation Schedule Weekdays')
     hvac_op_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,6,0,0), 0.0)
     hvac_op_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,22,0,0), 1.0)
     hvac_op_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,24,0,0), 0.0)
     hvac_op_sch.setSummerDesignDaySchedule(hvac_op_sch.defaultDaySchedule)
     #saturdays and winter design days
     saturday_rule = OpenStudio::Model::ScheduleRule.new(hvac_op_sch)
-    saturday_rule.setName("HVAC Operation Schedule Saturday Rule")
+    saturday_rule.setName('HVAC Operation Schedule Saturday Rule')
     saturday_rule.setApplySaturday(true)   
     saturday = saturday_rule.daySchedule  
-    saturday.setName("HVAC Operation Schedule Saturday")
+    saturday.setName('HVAC Operation Schedule Saturday')
     saturday.addValue(OpenStudio::Time.new(0,6,0,0), 0.0)
     saturday.addValue(OpenStudio::Time.new(0,18,0,0), 1.0)
     saturday.addValue(OpenStudio::Time.new(0,24,0,0), 0.0)
     hvac_op_sch.setWinterDesignDaySchedule(saturday)
     #sundays
     sunday_rule = OpenStudio::Model::ScheduleRule.new(hvac_op_sch)
-    sunday_rule.setName("HVAC Operation Schedule Sunday Rule")
+    sunday_rule.setName('HVAC Operation Schedule Sunday Rule')
     sunday_rule.setApplySunday(true)   
     sunday = sunday_rule.daySchedule  
-    sunday.setName("HVAC Operation Schedule Sunday")
+    sunday.setName('HVAC Operation Schedule Sunday')
     sunday.addValue(OpenStudio::Time.new(0,24,0,0), 0.0)
     
     # Motorized OA damper schedule min OA schedule
@@ -413,28 +413,28 @@ class OpenStudio::Model::Model
     # For: AllOtherDays,Until: 24:00,0.0
     #weekdays and summer design days
     motorized_oa_damper_sch = OpenStudio::Model::ScheduleRuleset.new(self)
-    motorized_oa_damper_sch.setName("Motorized OA Damper Schedule")
-    motorized_oa_damper_sch.defaultDaySchedule.setName("Motorized OA Damper Schedule Weekdays") 
+    motorized_oa_damper_sch.setName('Motorized OA Damper Schedule')
+    motorized_oa_damper_sch.defaultDaySchedule.setName('Motorized OA Damper Schedule Weekdays')
     motorized_oa_damper_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,7,0,0), 0.0)
     motorized_oa_damper_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,22,0,0), 1.0)
     motorized_oa_damper_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,24,0,0), 0.0)
     motorized_oa_damper_sch.setSummerDesignDaySchedule(motorized_oa_damper_sch.defaultDaySchedule)
     #saturdays and winter design days
     saturday_rule = OpenStudio::Model::ScheduleRule.new(motorized_oa_damper_sch)
-    saturday_rule.setName("Motorized OA Damper Schedule Saturday Rule")
+    saturday_rule.setName('Motorized OA Damper Schedule Saturday Rule')
     saturday_rule.setApplySaturday(true)   
     saturday = saturday_rule.daySchedule  
-    saturday.setName("Motorized OA Damper Schedule Saturday")
+    saturday.setName('Motorized OA Damper Schedule Saturday')
     saturday.addValue(OpenStudio::Time.new(0,7,0,0), 0.0)
     saturday.addValue(OpenStudio::Time.new(0,18,0,0), 1.0)
     saturday.addValue(OpenStudio::Time.new(0,24,0,0), 0.0)
     motorized_oa_damper_sch.setWinterDesignDaySchedule(saturday)
     #sundays
     sunday_rule = OpenStudio::Model::ScheduleRule.new(motorized_oa_damper_sch)
-    sunday_rule.setName("Motorized OA Damper Schedule Sunday Rule")
+    sunday_rule.setName('Motorized OA Damper Schedule Sunday Rule')
     sunday_rule.setApplySunday(true)   
     sunday = sunday_rule.daySchedule  
-    sunday.setName("Motorized OA Damper Schedule Sunday")
+    sunday.setName('Motorized OA Damper Schedule Sunday')
     sunday.addValue(OpenStudio::Time.new(0,24,0,0), 0.0)    
       
     # Make a PSZ-AC for each zone
@@ -450,7 +450,7 @@ class OpenStudio::Model::Model
       # this systems is a constant volume system with no VAV terminals, 
       # and therfore needs different default settings
       air_loop_sizing = air_loop.sizingSystem # TODO units
-      air_loop_sizing.setTypeofLoadtoSizeOn("Sensible")
+      air_loop_sizing.setTypeofLoadtoSizeOn('Sensible')
       air_loop_sizing.autosizeDesignOutdoorAirFlowRate
       air_loop_sizing.setMinimumSystemAirFlowRatio(1.0)
       air_loop_sizing.setPreheatDesignTemperature(7.0)
@@ -459,16 +459,16 @@ class OpenStudio::Model::Model
       air_loop_sizing.setPrecoolDesignHumidityRatio(0.008)
       air_loop_sizing.setCentralCoolingDesignSupplyAirTemperature(12.8)
       air_loop_sizing.setCentralHeatingDesignSupplyAirTemperature(40.0)
-      air_loop_sizing.setSizingOption("Coincident")
+      air_loop_sizing.setSizingOption('Coincident')
       air_loop_sizing.setAllOutdoorAirinCooling(false)
       air_loop_sizing.setAllOutdoorAirinHeating(false)
       air_loop_sizing.setCentralCoolingDesignSupplyAirHumidityRatio(0.0085)
       air_loop_sizing.setCentralHeatingDesignSupplyAirHumidityRatio(0.0080)
-      air_loop_sizing.setCoolingDesignAirFlowMethod("DesignDay")
+      air_loop_sizing.setCoolingDesignAirFlowMethod('DesignDay')
       air_loop_sizing.setCoolingDesignAirFlowRate(0.0)
-      air_loop_sizing.setHeatingDesignAirFlowMethod("DesignDay")
+      air_loop_sizing.setHeatingDesignAirFlowMethod('DesignDay')
       air_loop_sizing.setHeatingDesignAirFlowRate(0.0)
-      air_loop_sizing.setSystemOutdoorAirMethod("ZoneSum")
+      air_loop_sizing.setSystemOutdoorAirMethod('ZoneSum')
       
       # Add a setpoint manager single zone reheat to control the
       # supply air temperature based on the needs of this zone
@@ -476,21 +476,21 @@ class OpenStudio::Model::Model
       setpoint_mgr_single_zone_reheat.setControlZone(zone)        
       
       fan = nil
-      if prototype_input["unitary_ac_fan_type"] == "ConstantVolume"
+      if prototype_input['unitary_ac_fan_type'] == 'ConstantVolume'
       
         fan = OpenStudio::Model::FanConstantVolume.new(self,self.alwaysOnDiscreteSchedule)
         fan.setName("#{zone.name} PSZ-AC Fan")
         fan_static_pressure_in_h2o = 2.5    
-        fan_static_pressure_pa = OpenStudio.convert(fan_static_pressure_in_h2o, "inH_{2}O","Pa").get
+        fan_static_pressure_pa = OpenStudio.convert(fan_static_pressure_in_h2o, 'inH_{2}O','Pa').get
         fan.setPressureRise(fan_static_pressure_pa)  
         fan.setFanEfficiency(0.54)
         fan.setMotorEfficiency(0.90)
-      elsif prototype_input["unitary_ac_fan_type"] == "Cycling" 
+      elsif prototype_input['unitary_ac_fan_type'] == 'Cycling'
       
         fan = OpenStudio::Model::FanOnOff.new(self,self.alwaysOnDiscreteSchedule)
         fan.setName("#{zone.name} PSZ-AC Fan")
         fan_static_pressure_in_h2o = 2.5    
-        fan_static_pressure_pa = OpenStudio.convert(fan_static_pressure_in_h2o, "inH_{2}O","Pa").get
+        fan_static_pressure_pa = OpenStudio.convert(fan_static_pressure_in_h2o, 'inH_{2}O','Pa').get
         fan.setPressureRise(fan_static_pressure_pa)  
         fan.setFanEfficiency(0.54)
         fan.setMotorEfficiency(0.90)
@@ -498,10 +498,10 @@ class OpenStudio::Model::Model
       end
      
       htg_coil = nil
-      if prototype_input["unitary_ac_heating_type"] == "Gas"
+      if prototype_input['unitary_ac_heating_type'] == 'Gas'
         htg_coil = OpenStudio::Model::CoilHeatingGas.new(self,self.alwaysOnDiscreteSchedule)
         htg_coil.setName("#{zone.name} PSZ-AC Gas Htg Coil")
-      elsif prototype_input["unitary_ac_heating_type"] == "Single Speed Heat Pump"
+      elsif prototype_input['unitary_ac_heating_type'] == 'Single Speed Heat Pump'
         htg_cap_f_of_temp = OpenStudio::Model::CurveCubic.new(self)
         htg_cap_f_of_temp.setCoefficient1Constant(0.758746)
         htg_cap_f_of_temp.setCoefficient2x(0.027626)
@@ -553,17 +553,17 @@ class OpenStudio::Model::Model
       end
       
       supplemental_htg_coil = nil
-      if prototype_input["unitary_ac_supplemental_heating_type"] == "Electric"
+      if prototype_input['unitary_ac_supplemental_heating_type'] == 'Electric'
         supplemental_htg_coil = OpenStudio::Model::CoilHeatingGas.new(self,self.alwaysOnDiscreteSchedule)
         supplemental_htg_coil.setName("#{zone.name} PSZ-AC Electric Backup Htg Coil")
-      elsif prototype_input["unitary_ac_supplemental_heating_type"] == "Gas"
+      elsif prototype_input['unitary_ac_supplemental_heating_type'] == 'Gas'
         supplemental_htg_coil = OpenStudio::Model::CoilHeatingGas.new(self,self.alwaysOnDiscreteSchedule)
         supplemental_htg_coil.setName("#{zone.name} PSZ-AC Gas Backup Htg Coil") 
       end
 
 
       clg_coil = nil
-      if prototype_input["unitary_ac_cooling_type"] == "Two Speed DX AC"
+      if prototype_input['unitary_ac_cooling_type'] == 'Two Speed DX AC'
       
         clg_cap_f_of_temp = OpenStudio::Model::CurveBiquadratic.new(self)
         clg_cap_f_of_temp.setCoefficient1Constant(0.42415)
@@ -649,7 +649,7 @@ class OpenStudio::Model::Model
         clg_coil.setBasinHeaterCapacity(10)
         clg_coil.setBasinHeaterSetpointTemperature(2.0)
       
-      elsif prototype_input["unitary_ac_cooling_type"] == "Single Speed DX AC"
+      elsif prototype_input['unitary_ac_cooling_type'] == 'Single Speed DX AC'
       
         clg_cap_f_of_temp = OpenStudio::Model::CurveBiquadratic.new(self)
         clg_cap_f_of_temp.setCoefficient1Constant(0.9712123)
@@ -708,7 +708,7 @@ class OpenStudio::Model::Model
 
         clg_coil.setName("#{zone.name} PSZ-AC 1spd DX AC Clg Coil")
       
-      elsif prototype_input["unitary_ac_cooling_type"] == "Single Speed Heat Pump"
+      elsif prototype_input['unitary_ac_cooling_type'] == 'Single Speed Heat Pump'
       
         clg_cap_f_of_temp = OpenStudio::Model::CurveBiquadratic.new(self)
         clg_cap_f_of_temp.setCoefficient1Constant(0.766956)
@@ -776,10 +776,10 @@ class OpenStudio::Model::Model
       oa_system.setName("#{zone.name} PSZ-AC OA Sys")
 
       #heat exchanger on oa system
-      if prototype_input["hx"] == true
+      if prototype_input['hx']
         heat_exchanger = OpenStudio::Model::HeatExchangerAirToAirSensibleAndLatent.new(self)
         heat_exchanger.setName("#{zone.name} PSZ-AC HX")
-        heat_exchanger.setHeatExchangerType("Rotary")
+        heat_exchanger.setHeatExchangerType('Rotary')
         heat_exchanger.setSensibleEffectivenessat100CoolingAirFlow(0.7)
         heat_exchanger.setSensibleEffectivenessat75CoolingAirFlow(0.6)
         heat_exchanger.setLatentEffectivenessat100CoolingAirFlow(0.7)
@@ -795,7 +795,7 @@ class OpenStudio::Model::Model
         if oa_node.is_initialized
           heat_exchanger.addToNode(oa_node.get)
         else
-          OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "No outdoor air node found, can not add heat exchanger")
+          OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'No outdoor air node found, can not add heat exchanger')
           return false
         end
       end
@@ -806,7 +806,7 @@ class OpenStudio::Model::Model
 
       # Wrap coils in a unitary system or not, depending
       # on the system type.
-      if prototype_input["unitary_ac_fan_type"] == "Cycling"
+      if prototype_input['unitary_ac_fan_type'] == 'Cycling'
       
         unitary_system = OpenStudio::Model::AirLoopHVACUnitaryHeatPumpAirToAir.new(self,
                                                                                   self.alwaysOnDiscreteSchedule,
@@ -816,13 +816,13 @@ class OpenStudio::Model::Model
                                                                                   supplemental_htg_coil)
         unitary_system.setName("#{zone.name} Unitary HP")
         unitary_system.setControllingZone(zone)
-        unitary_system.setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(OpenStudio.convert(40,"F","C").get)
-        unitary_system.setFanPlacement("BlowThrough")
+        unitary_system.setMaximumOutdoorDryBulbTemperatureforSupplementalHeaterOperation(OpenStudio.convert(40,'F','C').get)
+        unitary_system.setFanPlacement('BlowThrough')
         unitary_system.setSupplyAirFanOperatingModeSchedule(hvac_op_sch)
         unitary_system.addToNode(supply_inlet_node)
         
-        setpoint_mgr_single_zone_reheat.setMinimumSupplyAirTemperature(OpenStudio.convert(55,"F","C").get)
-        setpoint_mgr_single_zone_reheat.setMaximumSupplyAirTemperature(OpenStudio.convert(104,"F","C").get)
+        setpoint_mgr_single_zone_reheat.setMinimumSupplyAirTemperature(OpenStudio.convert(55,'F','C').get)
+        setpoint_mgr_single_zone_reheat.setMaximumSupplyAirTemperature(OpenStudio.convert(104,'F','C').get)
  
       else
       
@@ -846,8 +846,8 @@ class OpenStudio::Model::Model
           clg_coil.addToNode(supply_inlet_node)
         end
       
-        setpoint_mgr_single_zone_reheat.setMinimumSupplyAirTemperature(OpenStudio.convert(50,"F","C").get)
-        setpoint_mgr_single_zone_reheat.setMaximumSupplyAirTemperature(OpenStudio.convert(122,"F","C").get)
+        setpoint_mgr_single_zone_reheat.setMinimumSupplyAirTemperature(OpenStudio.convert(50,'F','C').get)
+        setpoint_mgr_single_zone_reheat.setMaximumSupplyAirTemperature(OpenStudio.convert(122,'F','C').get)
       
       end
       
@@ -856,7 +856,7 @@ class OpenStudio::Model::Model
       
       # Attach the nightcycle manager to the supply outlet node
       setpoint_mgr_single_zone_reheat.addToNode(air_loop.supplyOutletNode)
-      air_loop.setNightCycleControlType("CycleOnAny")
+      air_loop.setNightCycleControlType('CycleOnAny')
       
       # Create a diffuser and attach the zone/diffuser pair to the air loop
       diffuser = OpenStudio::Model::AirTerminalSingleDuctUncontrolled.new(self,self.alwaysOnDiscreteSchedule)
@@ -871,77 +871,77 @@ class OpenStudio::Model::Model
 
   def add_chiller(hvac_standards, chlr_props)
     
-    curve_biquadratics = hvac_standards["curve_biquadratics"]
-    curve_quadratics = hvac_standards["curve_quadratics"]
-    curve_bicubics = hvac_standards["curve_bicubics"]
+    curve_biquadratics = hvac_standards['curve_biquadratics']
+    curve_quadratics = hvac_standards['curve_quadratics']
+    curve_bicubics = hvac_standards['curve_bicubics']
   
     # Make the CAPFT curve
-    capft_properties = find_object(curve_biquadratics, {"name"=>chlr_props["capft"]})
+    capft_properties = find_object(curve_biquadratics, {'name'=>chlr_props['capft']})
     ccFofT = OpenStudio::Model::CurveBiquadratic.new(self)
-    ccFofT.setName(capft_properties["name"])
-    ccFofT.setCoefficient1Constant(capft_properties["coeff_1"])
-    ccFofT.setCoefficient2x(capft_properties["coeff_2"])
-    ccFofT.setCoefficient3xPOW2(capft_properties["coeff_3"])
-    ccFofT.setCoefficient4y(capft_properties["coeff_4"])
-    ccFofT.setCoefficient5yPOW2(capft_properties["coeff_5"])
-    ccFofT.setCoefficient6xTIMESY(capft_properties["coeff_6"])
-    ccFofT.setMinimumValueofx(capft_properties["min_x"])
-    ccFofT.setMaximumValueofx(capft_properties["max_x"])
-    ccFofT.setMinimumValueofy(capft_properties["min_y"])
-    ccFofT.setMaximumValueofy(capft_properties["max_y"])
+    ccFofT.setName(capft_properties['name'])
+    ccFofT.setCoefficient1Constant(capft_properties['coeff_1'])
+    ccFofT.setCoefficient2x(capft_properties['coeff_2'])
+    ccFofT.setCoefficient3xPOW2(capft_properties['coeff_3'])
+    ccFofT.setCoefficient4y(capft_properties['coeff_4'])
+    ccFofT.setCoefficient5yPOW2(capft_properties['coeff_5'])
+    ccFofT.setCoefficient6xTIMESY(capft_properties['coeff_6'])
+    ccFofT.setMinimumValueofx(capft_properties['min_x'])
+    ccFofT.setMaximumValueofx(capft_properties['max_x'])
+    ccFofT.setMinimumValueofy(capft_properties['min_y'])
+    ccFofT.setMaximumValueofy(capft_properties['max_y'])
 
     # Make the EIRFT curve
-    eirft_properties = find_object(curve_biquadratics, {"name"=>chlr_props["eirft"]})
+    eirft_properties = find_object(curve_biquadratics, {'name'=>chlr_props['eirft']})
     eirToCorfOfT = OpenStudio::Model::CurveBiquadratic.new(self)
-    eirToCorfOfT.setName(eirft_properties["name"])
-    eirToCorfOfT.setCoefficient1Constant(eirft_properties["coeff_1"])
-    eirToCorfOfT.setCoefficient2x(eirft_properties["coeff_2"])
-    eirToCorfOfT.setCoefficient3xPOW2(eirft_properties["coeff_3"])
-    eirToCorfOfT.setCoefficient4y(eirft_properties["coeff_4"])
-    eirToCorfOfT.setCoefficient5yPOW2(eirft_properties["coeff_5"])
-    eirToCorfOfT.setCoefficient6xTIMESY(eirft_properties["coeff_6"])
-    eirToCorfOfT.setMinimumValueofx(eirft_properties["min_x"])
-    eirToCorfOfT.setMaximumValueofx(eirft_properties["max_x"])
-    eirToCorfOfT.setMinimumValueofy(eirft_properties["min_y"])
-    eirToCorfOfT.setMaximumValueofy(eirft_properties["max_y"])
+    eirToCorfOfT.setName(eirft_properties['name'])
+    eirToCorfOfT.setCoefficient1Constant(eirft_properties['coeff_1'])
+    eirToCorfOfT.setCoefficient2x(eirft_properties['coeff_2'])
+    eirToCorfOfT.setCoefficient3xPOW2(eirft_properties['coeff_3'])
+    eirToCorfOfT.setCoefficient4y(eirft_properties['coeff_4'])
+    eirToCorfOfT.setCoefficient5yPOW2(eirft_properties['coeff_5'])
+    eirToCorfOfT.setCoefficient6xTIMESY(eirft_properties['coeff_6'])
+    eirToCorfOfT.setMinimumValueofx(eirft_properties['min_x'])
+    eirToCorfOfT.setMaximumValueofx(eirft_properties['max_x'])
+    eirToCorfOfT.setMinimumValueofy(eirft_properties['min_y'])
+    eirToCorfOfT.setMaximumValueofy(eirft_properties['max_y'])
 
     # Make the EIRFPLR curve
     # which may be either a CurveBicubic or a CurveQuadratic based on chiller type
     eirToCorfOfPlr = nil
-    eirfplr_properties = find_object(curve_quadratics, {"name"=>chlr_props["eirfplr"]})
+    eirfplr_properties = find_object(curve_quadratics, {'name'=>chlr_props['eirfplr']})
     if eirfplr_properties
       eirToCorfOfPlr = OpenStudio::Model::CurveQuadratic.new(self)
-      eirToCorfOfPlr.setName(eirfplr_properties["name"])
-      eirToCorfOfPlr.setCoefficient1Constant(eirfplr_properties["coeff_1"])
-      eirToCorfOfPlr.setCoefficient2x(eirfplr_properties["coeff_2"])
-      eirToCorfOfPlr.setCoefficient3xPOW2(eirfplr_properties["coeff_3"])
-      eirToCorfOfPlr.setMinimumValueofx(eirfplr_properties["min_x"])
-      eirToCorfOfPlr.setMaximumValueofx(eirfplr_properties["max_x"])
+      eirToCorfOfPlr.setName(eirfplr_properties['name'])
+      eirToCorfOfPlr.setCoefficient1Constant(eirfplr_properties['coeff_1'])
+      eirToCorfOfPlr.setCoefficient2x(eirfplr_properties['coeff_2'])
+      eirToCorfOfPlr.setCoefficient3xPOW2(eirfplr_properties['coeff_3'])
+      eirToCorfOfPlr.setMinimumValueofx(eirfplr_properties['min_x'])
+      eirToCorfOfPlr.setMaximumValueofx(eirfplr_properties['max_x'])
     end
     
-    eirfplr_properties = find_object(curve_bicubics, {"name"=>chlr_props["eirfplr"]})
+    eirfplr_properties = find_object(curve_bicubics, {'name'=>chlr_props['eirfplr']})
     if eirfplr_properties
       eirToCorfOfPlr = OpenStudio::Model::CurveBicubic.new(self)
-      eirToCorfOfPlr.setName(eirft_properties["name"])
-      eirToCorfOfPlr.setCoefficient1Constant(eirfplr_properties["coeff_1"])
-      eirToCorfOfPlr.setCoefficient2x(eirfplr_properties["coeff_2"])
-      eirToCorfOfPlr.setCoefficient3xPOW2(eirfplr_properties["coeff_3"])
-      eirToCorfOfPlr.setCoefficient4y(eirfplr_properties["coeff_4"])
-      eirToCorfOfPlr.setCoefficient5yPOW2(eirfplr_properties["coeff_5"])
-      eirToCorfOfPlr.setCoefficient6xTIMESY(eirfplr_properties["coeff_6"])
-      eirToCorfOfPlr.setCoefficient7xPOW3 (eirfplr_properties["coeff_7"])
-      eirToCorfOfPlr.setCoefficient8yPOW3 (eirfplr_properties["coeff_8"])
-      eirToCorfOfPlr.setCoefficient9xPOW2TIMESY(eirfplr_properties["coeff_9"])
-      eirToCorfOfPlr.setCoefficient10xTIMESYPOW2 (eirfplr_properties["coeff_10"])
-      eirToCorfOfPlr.setMinimumValueofx(eirft_properties["min_x"])
-      eirToCorfOfPlr.setMaximumValueofx(eirft_properties["max_x"])
-      eirToCorfOfPlr.setMinimumValueofy(eirft_properties["min_y"])
-      eirToCorfOfPlr.setMaximumValueofy(eirft_properties["max_y"])
+      eirToCorfOfPlr.setName(eirft_properties['name'])
+      eirToCorfOfPlr.setCoefficient1Constant(eirfplr_properties['coeff_1'])
+      eirToCorfOfPlr.setCoefficient2x(eirfplr_properties['coeff_2'])
+      eirToCorfOfPlr.setCoefficient3xPOW2(eirfplr_properties['coeff_3'])
+      eirToCorfOfPlr.setCoefficient4y(eirfplr_properties['coeff_4'])
+      eirToCorfOfPlr.setCoefficient5yPOW2(eirfplr_properties['coeff_5'])
+      eirToCorfOfPlr.setCoefficient6xTIMESY(eirfplr_properties['coeff_6'])
+      eirToCorfOfPlr.setCoefficient7xPOW3 (eirfplr_properties['coeff_7'])
+      eirToCorfOfPlr.setCoefficient8yPOW3 (eirfplr_properties['coeff_8'])
+      eirToCorfOfPlr.setCoefficient9xPOW2TIMESY(eirfplr_properties['coeff_9'])
+      eirToCorfOfPlr.setCoefficient10xTIMESYPOW2 (eirfplr_properties['coeff_10'])
+      eirToCorfOfPlr.setMinimumValueofx(eirft_properties['min_x'])
+      eirToCorfOfPlr.setMaximumValueofx(eirft_properties['max_x'])
+      eirToCorfOfPlr.setMinimumValueofy(eirft_properties['min_y'])
+      eirToCorfOfPlr.setMaximumValueofy(eirft_properties['max_y'])
     end  
 
     chiller = OpenStudio::Model::ChillerElectricEIR.new(self,ccFofT,eirToCorfOfT,eirToCorfOfPlr)
-    chiller.setName("#{chlr_props["template"]} #{chlr_props["cooling_type"]} #{chlr_props["condenser_type"]} #{chlr_props["compressor_type"]} Chiller")
-    chiller.setReferenceCOP(chlr_props["minimum_cop"])
+    chiller.setName("#{chlr_props['template']} #{chlr_props['cooling_type']} #{chlr_props['condenser_type']} #{chlr_props['compressor_type']} Chiller")
+    chiller.setReferenceCOP(chlr_props['minimum_cop'])
     
     return chiller
 
@@ -951,21 +951,21 @@ class OpenStudio::Model::Model
 
     # Service water heating loop
     service_water_loop = OpenStudio::Model::PlantLoop.new(self)
-    service_water_loop.setName("Service Water Loop")
+    service_water_loop.setName('Service Water Loop')
 
     # Temperature schedule type limits
     temp_sch_type_limits = OpenStudio::Model::ScheduleTypeLimits.new(self)
-    temp_sch_type_limits.setName("Temperature Schedule Type Limits")
+    temp_sch_type_limits.setName('Temperature Schedule Type Limits')
     temp_sch_type_limits.setLowerLimitValue(0.0)
     temp_sch_type_limits.setUpperLimitValue(100.0)
-    temp_sch_type_limits.setNumericType("Continuous")
-    temp_sch_type_limits.setUnitType("Temperature")
+    temp_sch_type_limits.setNumericType('Continuous')
+    temp_sch_type_limits.setUnitType('Temperature')
     
     # Service water heating loop controls
-    swh_temp_f = prototype_input["service_water_temperature"]
+    swh_temp_f = prototype_input['service_water_temperature']
     swh_delta_t_r = 9 #9F delta-T    
-    swh_temp_c = OpenStudio.convert(swh_temp_f,"F","C").get
-    swh_delta_t_k = OpenStudio.convert(swh_delta_t_r,"R","K").get
+    swh_temp_c = OpenStudio.convert(swh_temp_f,'F','C').get
+    swh_delta_t_k = OpenStudio.convert(swh_delta_t_r,'R','K').get
     swh_temp_sch = OpenStudio::Model::ScheduleRuleset.new(self)
     swh_temp_sch.setName("Hot Water Loop Temp - #{swh_temp_f}F")
     swh_temp_sch.defaultDaySchedule().setName("Hot Water Loop Temp - #{swh_temp_f}F Default")
@@ -974,61 +974,61 @@ class OpenStudio::Model::Model
     swh_stpt_manager = OpenStudio::Model::SetpointManagerScheduled.new(self,swh_temp_sch)    
     swh_stpt_manager.addToNode(service_water_loop.supplyOutletNode)
     sizing_plant = service_water_loop.sizingPlant
-    sizing_plant.setLoopType("Heating")
+    sizing_plant.setLoopType('Heating')
     sizing_plant.setDesignLoopExitTemperature(swh_temp_c)
     sizing_plant.setLoopDesignTemperatureDifference(swh_delta_t_k)         
     
     # Service water heating pump
     swh_pump = OpenStudio::Model::PumpConstantSpeed.new(self)
-    swh_pump.setName("Service Water Loop Pump")
+    swh_pump.setName('Service Water Loop Pump')
     swh_pump_head_press_pa = 0.001 # As if there is no circulation pump
     swh_pump.setRatedPumpHead(swh_pump_head_press_pa)
     swh_pump.setMotorEfficiency(0.3)
-    swh_pump.setPumpControlType("Intermittent")
+    swh_pump.setPumpControlType('Intermittent')
     swh_pump.addToNode(service_water_loop.supplyInletNode)
     
     # Water heater
     # TODO Standards - Change water heater methodology to follow
-    # "Model Enhancements Appendix A."
-    water_heater_capacity_btu_per_hr = prototype_input["water_heater_capacity"]
-    water_heater_vol_gal = prototype_input["water_heater_volume"]
-    water_heater_fuel = prototype_input["water_heater_fuel"]
+    # 'Model Enhancements Appendix A.'
+    water_heater_capacity_btu_per_hr = prototype_input['water_heater_capacity']
+    water_heater_vol_gal = prototype_input['water_heater_volume']
+    water_heater_fuel = prototype_input['water_heater_fuel']
 
     # Assume the water heater is indoors at 70F for now
     default_water_heater_ambient_temp_sch = OpenStudio::Model::ScheduleRuleset.new(self)
-    default_water_heater_ambient_temp_sch.setName("Water Heater Ambient Temp Schedule - 70F")
-    default_water_heater_ambient_temp_sch.defaultDaySchedule.setName("Water Heater Ambient Temp Schedule - 70F Default")
+    default_water_heater_ambient_temp_sch.setName('Water Heater Ambient Temp Schedule - 70F')
+    default_water_heater_ambient_temp_sch.defaultDaySchedule.setName('Water Heater Ambient Temp Schedule - 70F Default')
     default_water_heater_ambient_temp_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,24,0,0),OpenStudio::convert(70,"F","C").get)
     default_water_heater_ambient_temp_sch.setScheduleTypeLimits(temp_sch_type_limits)
     
     # Water heater depends on the fuel type
     water_heater = OpenStudio::Model::WaterHeaterMixed.new(self)
     water_heater.setName("#{water_heater_vol_gal}gal #{water_heater_fuel} Water Heater - #{water_heater_capacity_btu_per_hr}btu/hr")
-    water_heater.setTankVolume(OpenStudio.convert(water_heater_vol_gal,"gal","m^3").get)
+    water_heater.setTankVolume(OpenStudio.convert(water_heater_vol_gal,'gal','m^3').get)
     water_heater.setSetpointTemperatureSchedule(swh_temp_sch)
-    water_heater.setAmbientTemperatureIndicator("Schedule")
+    water_heater.setAmbientTemperatureIndicator('Schedule')
     water_heater.setAmbientTemperatureSchedule(default_water_heater_ambient_temp_sch)
-    water_heater.setMaximumTemperatureLimit(OpenStudio::convert(180,"F","C").get)
-    water_heater.setDeadbandTemperatureDifference(OpenStudio.convert(3.6,"R","K").get)
-    water_heater.setHeaterControlType("Cycle")
-    water_heater.setHeaterMaximumCapacity(OpenStudio.convert(water_heater_capacity_btu_per_hr,"Btu/hr","W").get)
+    water_heater.setMaximumTemperatureLimit(OpenStudio::convert(180,'F','C').get)
+    water_heater.setDeadbandTemperatureDifference(OpenStudio.convert(3.6,'R','K').get)
+    water_heater.setHeaterControlType('Cycle')
+    water_heater.setHeaterMaximumCapacity(OpenStudio.convert(water_heater_capacity_btu_per_hr,'Btu/hr','W').get)
     water_heater.setOffCycleParasiticHeatFractiontoTank(0.8)
     water_heater.setIndirectWaterHeatingRecoveryTime(1.5) # 1.5hrs
-    if water_heater_fuel == "Electricity"
-      water_heater.setHeaterFuelType("Electricity")
+    if water_heater_fuel == 'Electricity'
+      water_heater.setHeaterFuelType('Electricity')
       water_heater.setHeaterThermalEfficiency(1.0)
       water_heater.setOffCycleParasiticFuelConsumptionRate(571)
-      water_heater.setOffCycleParasiticFuelType("Electricity")
+      water_heater.setOffCycleParasiticFuelType('Electricity')
       water_heater.setOnCycleParasiticFuelConsumptionRate(571)
-      water_heater.setOnCycleParasiticFuelType("Electricity")
+      water_heater.setOnCycleParasiticFuelType('Electricity')
       water_heater.setOffCycleLossCoefficienttoAmbientTemperature(1.21)
       water_heater.setOnCycleLossCoefficienttoAmbientTemperature(1.21)
-    elsif water_heater_fuel == "Natural Gas"
-      water_heater.setHeaterFuelType("NaturalGas")
+    elsif water_heater_fuel == 'Natural Gas'
+      water_heater.setHeaterFuelType('NaturalGas')
       water_heater.setHeaterThermalEfficiency(0.78)
       water_heater.setOffCycleParasiticFuelConsumptionRate(20)
-      water_heater.setOffCycleParasiticFuelType("NaturalGas")
-      water_heater.setOnCycleParasiticFuelType("NaturalGas")
+      water_heater.setOffCycleParasiticFuelType('NaturalGas')
+      water_heater.setOnCycleParasiticFuelType('NaturalGas')
       water_heater.setOffCycleLossCoefficienttoAmbientTemperature(6.0)
       water_heater.setOnCycleLossCoefficienttoAmbientTemperature(6.0)
     end
@@ -1052,7 +1052,7 @@ class OpenStudio::Model::Model
   
   def add_swh_end_uses(prototype_input, hvac_standards, swh_loop)
     
-    schedules = hvac_standards["schedules"]
+    schedules = hvac_standards['schedules']
     
     # Water use connection
     swh_connection = OpenStudio::Model::WaterUseConnections.new(self)
@@ -1060,25 +1060,25 @@ class OpenStudio::Model::Model
     # Water fixture definition
     # Peak flow rate
     water_fixture_def = OpenStudio::Model::WaterUseEquipmentDefinition.new(self)
-    rated_flow_rate_gal_per_min = prototype_input["service_water_peak_flowrate"]
-    rated_flow_rate_m3_per_s = OpenStudio.convert(rated_flow_rate_gal_per_min,"gal/min","m^3/s").get
+    rated_flow_rate_gal_per_min = prototype_input['service_water_peak_flowrate']
+    rated_flow_rate_m3_per_s = OpenStudio.convert(rated_flow_rate_gal_per_min,'gal/min','m^3/s').get
     water_fixture_def.setPeakFlowRate(rated_flow_rate_m3_per_s)
     # Target mixed water temperature
-    mixed_water_temp_f = prototype_input["water_use_temperature"]
+    mixed_water_temp_f = prototype_input['water_use_temperature']
     mixed_water_temp_sch = OpenStudio::Model::ScheduleRuleset.new(self)
-    mixed_water_temp_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,24,0,0),OpenStudio.convert(mixed_water_temp_f,"F","C").get)
+    mixed_water_temp_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,24,0,0),OpenStudio.convert(mixed_water_temp_f,'F','C').get)
     water_fixture_def.setTargetTemperatureSchedule(mixed_water_temp_sch)
     # Temperature of hot water when it reaches fixture
     # TODO enable hot water temperature at fixture to be set with OpenStudio
-    #hot_water_temp_at_fixture_f = prototype_input["service_water_temperature_at_fixture"]
+    #hot_water_temp_at_fixture_f = prototype_input['service_water_temperature_at_fixture']
     #hot_water_at_fixture_temp_sch = OpenStudio::Model::ScheduleRuleset.new(self)
-    #hot_water_at_fixture_temp_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,24,0,0),OpenStudio.convert(hot_water_temp_at_fixture_f,"F","C").get)
+    #hot_water_at_fixture_temp_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0,24,0,0),OpenStudio.convert(hot_water_temp_at_fixture_f,'F','C').get)
     #water_fixture_def.setHotWaterSupplyTemperatureSchedule(hot_water_at_fixture_temp_sch)    
     
     # Water use equipment
     #make the initial copy of the water fixture
     water_fixture = OpenStudio::Model::WaterUseEquipment.new(water_fixture_def)
-    schedule = self.add_schedule(schedules, prototype_input["service_water_flowrate_schedule"])
+    schedule = self.add_schedule(schedules, prototype_input['service_water_flowrate_schedule'])
     water_fixture.setFlowRateFractionSchedule(schedule)
     swh_connection.addWaterUseEquipment(water_fixture)
     

--- a/create_DOE_prototype_building/resources/Prototype.secondary_school.rb
+++ b/create_DOE_prototype_building/resources/Prototype.secondary_school.rb
@@ -161,9 +161,9 @@ class OpenStudio::Model::Model
     
   def add_hvac(building_type, building_vintage, climate_zone, prototype_input, hvac_standards)
    
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Started Adding HVAC")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started Adding HVAC')
     
-    system_to_space_map = define_hvac_system_map()
+    system_to_space_map = define_hvac_system_map
 
     chilled_water_loop = self.add_chw_loop(prototype_input, hvac_standards)
 
@@ -178,13 +178,13 @@ class OpenStudio::Model::Model
       system['space_names'].each do |space_name|
         space = self.getSpaceByName(space_name)
         if space.empty?
-          OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "No space called #{space_name} was found in the model")
+          OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', "No space called #{space_name} was found in the model")
           return false
         end
         space = space.get
         zone = space.thermalZone
         if zone.empty?
-          OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "No thermal zone created for space called #{space_name} was found in the model")
+          OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', "No thermal zone created for space called #{space_name} was found in the model")
           return false
         end
         thermal_zones << zone.get
@@ -195,16 +195,16 @@ class OpenStudio::Model::Model
         if hot_water_loop && chilled_water_loop
           self.add_vav(prototype_input, hvac_standards, hot_water_loop, chilled_water_loop, thermal_zones)
         else
-          OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "No hot water and chilled water plant loops in model")
+          OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', 'No hot water and chilled water plant loops in model')
           return false
         end
-      when "PSZ-AC"
+      when 'PSZ-AC'
         self.add_psz_ac(prototype_input, hvac_standards, thermal_zones)
       end
 
     end
 
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Finished adding HVAC")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished adding HVAC')
     
     return true
     

--- a/create_DOE_prototype_building/resources/Prototype.small_office.rb
+++ b/create_DOE_prototype_building/resources/Prototype.small_office.rb
@@ -59,9 +59,9 @@ class OpenStudio::Model::Model
      
   def add_hvac(building_type, building_vintage, climate_zone, prototype_input, hvac_standards)
    
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Started Adding HVAC")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started Adding HVAC')
     
-    system_to_space_map = define_hvac_system_map()
+    system_to_space_map = define_hvac_system_map
     
     system_to_space_map.each do |system|
 
@@ -70,26 +70,26 @@ class OpenStudio::Model::Model
       system['space_names'].each do |space_name|
         space = self.getSpaceByName(space_name)
         if space.empty?
-          OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "No space called #{space_name} was found in the model")
+          OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', "No space called #{space_name} was found in the model")
           return false
         end
         space = space.get
         zone = space.thermalZone
         if zone.empty?
-          OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "No thermal zone was created for the space called #{space_name}")
+          OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', "No thermal zone was created for the space called #{space_name}")
           return false
         end
         thermal_zones << zone.get
       end
 
       case system['type']
-      when "PSZ-AC"
+      when 'PSZ-AC'
         self.add_psz_ac(prototype_input, hvac_standards, thermal_zones)
       end
 
     end
     
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Finished adding HVAC")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished adding HVAC')
     
     return true
     

--- a/create_DOE_prototype_building/resources/Prototype.strip_model.rb
+++ b/create_DOE_prototype_building/resources/Prototype.strip_model.rb
@@ -1,5 +1,4 @@
 require 'openstudio'
-<<<<<<< HEAD
 require_relative 'Prototype.utilities'
 
 full_filename = ARGV[0]
@@ -17,22 +16,3 @@ if full_filename && (File.file?(full_filename) || File.file?(File.join(Dir.pwd, 
 else
 	puts "Pass a valid file path to this script"
 end
-=======
-require_relative 'prototype.utilities'
-
-folder = "C:/Users/yixing/Dropbox/LBNL/10.OSM reference buildings/Hotel Large/IDF for geometry/"
-
-filenames = ["ASHRAE90.1_HotelLarge_STD2007_San_Francisco", "ASHRAE90.1_HotelLarge_STD2010_San_Francisco", "ASHRAE90.1_HotelLarge_STD2013_San_Francisco","RefBldgLargeHotelPost1980_v1.4_7.2_3C_USA_CA_SAN_FRANCISCO"]
-
-filenames.each do |filename|
-  model = safe_load_model(folder + filename + ".osm")
-
-  model = strip_model(model)
-
-  new_path = OpenStudio::Path.new(filename + ".osm")
-  model.save(new_path, true)
-
-  puts "Stripped model was saved to #{filename}.osm"
-end
-
->>>>>>> master

--- a/create_DOE_prototype_building/resources/Prototype.strip_model.rb
+++ b/create_DOE_prototype_building/resources/Prototype.strip_model.rb
@@ -2,7 +2,7 @@
 require 'openstudio'
 require_relative 'utilities'
 
-model = safe_load_model("C:/GitRepos/OpenStudio-Prototype-Buildings/create_DOE_prototype_building/resources/prototype data/small_office_pret_1980_raw.osm")
+model = safe_load_model('C:/GitRepos/OpenStudio-Prototype-Buildings/create_DOE_prototype_building/resources/prototype data/small_office_pret_1980_raw.osm')
 
 model = strip_model(model)
 

--- a/create_DOE_prototype_building/resources/Prototype.strip_model.rb
+++ b/create_DOE_prototype_building/resources/Prototype.strip_model.rb
@@ -1,13 +1,19 @@
 
 require 'openstudio'
-require_relative 'utilities'
+require_relative 'Prototype.utilities'
 
-model = safe_load_model('C:/GitRepos/OpenStudio-Prototype-Buildings/create_DOE_prototype_building/resources/prototype data/small_office_pret_1980_raw.osm')
+full_filename = ARGV[0]
 
-model = strip_model(model)
+if full_filename && (File.file?(full_filename) || File.file?(File.join(Dir.pwd, full_filename)))
+	model = safe_load_model(full_filename)
 
-new_path = OpenStudio::Path.new("#{Dir.pwd}/stripped_model.osm")
+	model = strip_model(model)
 
-model.save(new_path, true)
+	new_path = OpenStudio::Path.new("#{Dir.pwd}/stripped_model.osm")
 
-puts "Stripped model was saved to #{new_path}"
+	model.save(new_path, true)
+
+	puts "Stripped model was saved to #{new_path}"
+else
+	puts "Pass a valid file path to this script"
+end

--- a/create_DOE_prototype_building/resources/Prototype.utilities.rb
+++ b/create_DOE_prototype_building/resources/Prototype.utilities.rb
@@ -6,13 +6,13 @@ def safe_load_model(model_path_string)
     versionTranslator = OpenStudio::OSVersion::VersionTranslator.new 
     model = versionTranslator.loadModel(model_path)
     if model.empty?
-      OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "Version translation failed for #{model_path_string}")
+      OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', "Version translation failed for #{model_path_string}")
       return false
     else
       model = model.get
     end
   else
-    OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "#{model_path_string} couldn't be found")
+    OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', "#{model_path_string} couldn't be found")
     return false
   end
   return model
@@ -24,7 +24,7 @@ def safe_load_sql(sql_path_string)
   if OpenStudio::exists(sql_path)
     sql = OpenStudio::SqlFile.new(sql_path)
   else
-    OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "#{sql_path} couldn't be found")
+    OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', "#{sql_path} couldn't be found")
     return false
   end
   return sql
@@ -162,7 +162,7 @@ def find_objects(hash_of_objects, search_criteria, capacity = nil)
   # Check the number of matching objects found
   if matching_objects.size == 0
     desired_object = nil
-    OpenStudio::logFree(OpenStudio::Warn, "openstudio.model.Model", "Find objects search criteria returned no results. Search criteria: #{search_criteria}, capacity = #{capacity}.  Called from #{caller(0)[1]}.")
+    OpenStudio::logFree(OpenStudio::Warn, 'openstudio.model.Model', "Find objects search criteria returned no results. Search criteria: #{search_criteria}, capacity = #{capacity}.  Called from #{caller(0)[1]}.")
   end
   
   return matching_objects
@@ -192,7 +192,7 @@ def find_object(hash_of_objects, search_criteria, capacity = nil)
       end
     end
     # Skip objects that don't meet all search criteria
-    next if meets_all_search_criteria == false
+    next if !meets_all_search_criteria
     # If made it here, object matches all search criteria
     search_criteria_matching_objects << object
   end
@@ -218,12 +218,12 @@ def find_object(hash_of_objects, search_criteria, capacity = nil)
   # Check the number of matching objects found
   if matching_objects.size == 0
     desired_object = nil
-    OpenStudio::logFree(OpenStudio::Warn, "openstudio.model.Model", "Find object search criteria returned no results. Search criteria: #{search_criteria}, capacity = #{capacity}.  Called from #{caller(0)[1]}")
+    OpenStudio::logFree(OpenStudio::Warn, 'openstudio.model.Model', "Find object search criteria returned no results. Search criteria: #{search_criteria}, capacity = #{capacity}.  Called from #{caller(0)[1]}")
   elsif matching_objects.size == 1
     desired_object = matching_objects[0]
   else 
     desired_object = matching_objects[0]
-    OpenStudio::logFree(OpenStudio::Warn, "openstudio.model.Model", "Find object search criteria returned #{matching_objects.size} results, the first one will be returned. Search criteria: #{search_criteria} Called from #{caller(0)[1]}.  All results: \n #{matching_objects.join("\n")}")
+    OpenStudio::logFree(OpenStudio::Warn, 'openstudio.model.Model', "Find object search criteria returned #{matching_objects.size} results, the first one will be returned. Search criteria: #{search_criteria} Called from #{caller(0)[1]}.  All results: \n #{matching_objects.join("\n")}")
   end
  
   return desired_object

--- a/create_DOE_prototype_building/resources/Standards.ChillerElectricEIR.rb
+++ b/create_DOE_prototype_building/resources/Standards.ChillerElectricEIR.rb
@@ -4,17 +4,17 @@ class OpenStudio::Model::ChillerElectricEIR
 
   def setStandardEfficiencyAndCurves(template, hvac_standards)
   
-    chillers = hvac_standards["chillers"]
-    curve_biquadratics = hvac_standards["curve_biquadratics"]
-    curve_quadratics = hvac_standards["curve_quadratics"]
-    curve_bicubics = hvac_standards["curve_bicubics"]
+    chillers = hvac_standards['chillers']
+    curve_biquadratics = hvac_standards['curve_biquadratics']
+    curve_quadratics = hvac_standards['curve_quadratics']
+    curve_bicubics = hvac_standards['curve_bicubics']
   
     # Define the criteria to find the chiller properties
     # in the hvac standards data set.
     search_criteria = {}
-    search_criteria["template"] = template
+    search_criteria['template'] = template
     cooling_type = self.condenserType
-    search_criteria["cooling_type"] = cooling_type
+    search_criteria['cooling_type'] = cooling_type
     
     # TODO Standards replace this with a mechanism to store this
     # data in the chiller object itself.
@@ -22,104 +22,104 @@ class OpenStudio::Model::ChillerElectricEIR
     name = self.name.get
     condenser_type = nil
     compressor_type = nil
-    if name.include?("AirCooled")
-      if name.include?("WithCondenser")
-        condenser_type = "WithCondenser"
-      elsif name.include?("WithoutCondenser")
-        condenser_type = "WithoutCondenser"
+    if name.include?('AirCooled')
+      if name.include?('WithCondenser')
+        condenser_type = 'WithCondenser'
+      elsif name.include?('WithoutCondenser')
+        condenser_type = 'WithoutCondenser'
       end
-    elsif name.include("WaterCooled")
-      if name.include?("Reciprocating")
-        compressor_type = "Reciprocating"
-      elsif name.include?("Rotary Screw")
-        compressor_type = "Rotary Screw"
-      elsif  name.include?("Scroll")
-        compressor_type = "Scroll"
+    elsif name.include('WaterCooled')
+      if name.include?('Reciprocating')
+        compressor_type = 'Reciprocating'
+      elsif name.include?('Rotary Screw')
+        compressor_type = 'Rotary Screw'
+      elsif  name.include?('Scroll')
+        compressor_type = 'Scroll'
       end
     end
     unless condenser_type.nil?
-      search_criteria["condenser_type"] = condenser_type
+      search_criteria['condenser_type'] = condenser_type
     end
     unless compressor_type.nil?
-      search_criteria["compressor_type"] = compressor_type
+      search_criteria['compressor_type'] = compressor_type
     end    
     
     # Get the chiller capacity
     return false if self.referenceCapacity.empty?
     capacity_w = self.referenceCapacity.get
-    capacity_tons = OpenStudio.convert(capacity_w, "W", "ton").get
+    capacity_tons = OpenStudio.convert(capacity_w, 'W', 'ton').get
 
     chlr_props = find_object(chillers, search_criteria, capacity_tons)
     return false if chlr_props.nil?
 
     # Make the CAPFT curve
-    capft_properties = find_object(curve_biquadratics, {"name"=>chlr_props["capft"]})
+    capft_properties = find_object(curve_biquadratics, {'name'=>chlr_props['capft']})
     return false if capft_properties.nil?
     ccFofT = self.coolingCapacityFunctionOfTemperature
-    ccFofT.setName(capft_properties["name"])
-    ccFofT.setCoefficient1Constant(capft_properties["coeff_1"])
-    ccFofT.setCoefficient2x(capft_properties["coeff_2"])
-    ccFofT.setCoefficient3xPOW2(capft_properties["coeff_3"])
-    ccFofT.setCoefficient4y(capft_properties["coeff_4"])
-    ccFofT.setCoefficient5yPOW2(capft_properties["coeff_5"])
-    ccFofT.setCoefficient6xTIMESY(capft_properties["coeff_6"])
-    ccFofT.setMinimumValueofx(capft_properties["min_x"])
-    ccFofT.setMaximumValueofx(capft_properties["max_x"])
-    ccFofT.setMinimumValueofy(capft_properties["min_y"])
-    ccFofT.setMaximumValueofy(capft_properties["max_y"])
+    ccFofT.setName(capft_properties['name'])
+    ccFofT.setCoefficient1Constant(capft_properties['coeff_1'])
+    ccFofT.setCoefficient2x(capft_properties['coeff_2'])
+    ccFofT.setCoefficient3xPOW2(capft_properties['coeff_3'])
+    ccFofT.setCoefficient4y(capft_properties['coeff_4'])
+    ccFofT.setCoefficient5yPOW2(capft_properties['coeff_5'])
+    ccFofT.setCoefficient6xTIMESY(capft_properties['coeff_6'])
+    ccFofT.setMinimumValueofx(capft_properties['min_x'])
+    ccFofT.setMaximumValueofx(capft_properties['max_x'])
+    ccFofT.setMinimumValueofy(capft_properties['min_y'])
+    ccFofT.setMaximumValueofy(capft_properties['max_y'])
 
     # Make the EIRFT curve
-    eirft_properties = find_object(curve_biquadratics, {"name"=>chlr_props["eirft"]})
+    eirft_properties = find_object(curve_biquadratics, {'name'=>chlr_props['eirft']})
     return false if eirft_properties.nil?
     eirToCorfOfT = self.electricInputToCoolingOutputRatioFunctionOfTemperature
-    eirToCorfOfT.setName(eirft_properties["name"])
-    eirToCorfOfT.setCoefficient1Constant(eirft_properties["coeff_1"])
-    eirToCorfOfT.setCoefficient2x(eirft_properties["coeff_2"])
-    eirToCorfOfT.setCoefficient3xPOW2(eirft_properties["coeff_3"])
-    eirToCorfOfT.setCoefficient4y(eirft_properties["coeff_4"])
-    eirToCorfOfT.setCoefficient5yPOW2(eirft_properties["coeff_5"])
-    eirToCorfOfT.setCoefficient6xTIMESY(eirft_properties["coeff_6"])
-    eirToCorfOfT.setMinimumValueofx(eirft_properties["min_x"])
-    eirToCorfOfT.setMaximumValueofx(eirft_properties["max_x"])
-    eirToCorfOfT.setMinimumValueofy(eirft_properties["min_y"])
-    eirToCorfOfT.setMaximumValueofy(eirft_properties["max_y"])
+    eirToCorfOfT.setName(eirft_properties['name'])
+    eirToCorfOfT.setCoefficient1Constant(eirft_properties['coeff_1'])
+    eirToCorfOfT.setCoefficient2x(eirft_properties['coeff_2'])
+    eirToCorfOfT.setCoefficient3xPOW2(eirft_properties['coeff_3'])
+    eirToCorfOfT.setCoefficient4y(eirft_properties['coeff_4'])
+    eirToCorfOfT.setCoefficient5yPOW2(eirft_properties['coeff_5'])
+    eirToCorfOfT.setCoefficient6xTIMESY(eirft_properties['coeff_6'])
+    eirToCorfOfT.setMinimumValueofx(eirft_properties['min_x'])
+    eirToCorfOfT.setMaximumValueofx(eirft_properties['max_x'])
+    eirToCorfOfT.setMinimumValueofy(eirft_properties['min_y'])
+    eirToCorfOfT.setMaximumValueofy(eirft_properties['max_y'])
 
     # Make the EIRFPLR curve
     # which may be either a CurveBicubic or a CurveQuadratic based on chiller type
     eirToCorfOfPlr = nil
-    eirfplr_properties = find_object(curve_quadratics, {"name"=>chlr_props["eirfplr"]})
+    eirfplr_properties = find_object(curve_quadratics, {'name'=>chlr_props['eirfplr']})
     if eirfplr_properties
       eirToCorfOfPlr = OpenStudio::Model::CurveQuadratic.new(self.model)
-      eirToCorfOfPlr.setName(eirfplr_properties["name"])
-      eirToCorfOfPlr.setCoefficient1Constant(eirfplr_properties["coeff_1"])
-      eirToCorfOfPlr.setCoefficient2x(eirfplr_properties["coeff_2"])
-      eirToCorfOfPlr.setCoefficient3xPOW2(eirfplr_properties["coeff_3"])
-      eirToCorfOfPlr.setMinimumValueofx(eirfplr_properties["min_x"])
-      eirToCorfOfPlr.setMaximumValueofx(eirfplr_properties["max_x"])
+      eirToCorfOfPlr.setName(eirfplr_properties['name'])
+      eirToCorfOfPlr.setCoefficient1Constant(eirfplr_properties['coeff_1'])
+      eirToCorfOfPlr.setCoefficient2x(eirfplr_properties['coeff_2'])
+      eirToCorfOfPlr.setCoefficient3xPOW2(eirfplr_properties['coeff_3'])
+      eirToCorfOfPlr.setMinimumValueofx(eirfplr_properties['min_x'])
+      eirToCorfOfPlr.setMaximumValueofx(eirfplr_properties['max_x'])
     end
     
-    eirfplr_properties = find_object(curve_bicubics, {"name"=>chlr_props["eirfplr"]})
+    eirfplr_properties = find_object(curve_bicubics, {'name'=>chlr_props['eirfplr']})
     if eirfplr_properties
       eirToCorfOfPlr = OpenStudio::Model::CurveBicubic.new(self.model)
-      eirToCorfOfPlr.setName(eirft_properties["name"])
-      eirToCorfOfPlr.setCoefficient1Constant(eirfplr_properties["coeff_1"])
-      eirToCorfOfPlr.setCoefficient2x(eirfplr_properties["coeff_2"])
-      eirToCorfOfPlr.setCoefficient3xPOW2(eirfplr_properties["coeff_3"])
-      eirToCorfOfPlr.setCoefficient4y(eirfplr_properties["coeff_4"])
-      eirToCorfOfPlr.setCoefficient5yPOW2(eirfplr_properties["coeff_5"])
-      eirToCorfOfPlr.setCoefficient6xTIMESY(eirfplr_properties["coeff_6"])
-      eirToCorfOfPlr.setCoefficient7xPOW3 (eirfplr_properties["coeff_7"])
-      eirToCorfOfPlr.setCoefficient8yPOW3 (eirfplr_properties["coeff_8"])
-      eirToCorfOfPlr.setCoefficient9xPOW2TIMESY(eirfplr_properties["coeff_9"])
-      eirToCorfOfPlr.setCoefficient10xTIMESYPOW2 (eirfplr_properties["coeff_10"])
-      eirToCorfOfPlr.setMinimumValueofx(eirft_properties["min_x"])
-      eirToCorfOfPlr.setMaximumValueofx(eirft_properties["max_x"])
-      eirToCorfOfPlr.setMinimumValueofy(eirft_properties["min_y"])
-      eirToCorfOfPlr.setMaximumValueofy(eirft_properties["max_y"])
+      eirToCorfOfPlr.setName(eirft_properties['name'])
+      eirToCorfOfPlr.setCoefficient1Constant(eirfplr_properties['coeff_1'])
+      eirToCorfOfPlr.setCoefficient2x(eirfplr_properties['coeff_2'])
+      eirToCorfOfPlr.setCoefficient3xPOW2(eirfplr_properties['coeff_3'])
+      eirToCorfOfPlr.setCoefficient4y(eirfplr_properties['coeff_4'])
+      eirToCorfOfPlr.setCoefficient5yPOW2(eirfplr_properties['coeff_5'])
+      eirToCorfOfPlr.setCoefficient6xTIMESY(eirfplr_properties['coeff_6'])
+      eirToCorfOfPlr.setCoefficient7xPOW3 (eirfplr_properties['coeff_7'])
+      eirToCorfOfPlr.setCoefficient8yPOW3 (eirfplr_properties['coeff_8'])
+      eirToCorfOfPlr.setCoefficient9xPOW2TIMESY(eirfplr_properties['coeff_9'])
+      eirToCorfOfPlr.setCoefficient10xTIMESYPOW2 (eirfplr_properties['coeff_10'])
+      eirToCorfOfPlr.setMinimumValueofx(eirft_properties['min_x'])
+      eirToCorfOfPlr.setMaximumValueofx(eirft_properties['max_x'])
+      eirToCorfOfPlr.setMinimumValueofy(eirft_properties['min_y'])
+      eirToCorfOfPlr.setMaximumValueofy(eirft_properties['max_y'])
     end  
 
     # Set the efficiency value
-    cop = chlr_props["minimum_cop"]
+    cop = chlr_props['minimum_cop']
     self.setReferenceCOP(cop)
     
     # Set the performance curves
@@ -130,7 +130,7 @@ class OpenStudio::Model::ChillerElectricEIR
     # Append the name with size and kw/ton
     kw_per_ton = cop_to_kw_per_ton(cop)
     self.setName("#{name} #{capacity_tons.round}tons #{kw_per_ton.round(1)}kW/ton")
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.ChillerElectricEIR", "For #{template}: #{self.name}: #{cooling_type} #{condenser_type} #{compressor_type} Capacity = #{capacity_tons.round}tons; COP = #{cop} (#{kw_per_ton.round(1)}kW/ton)")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.ChillerElectricEIR', "For #{template}: #{self.name}: #{cooling_type} #{condenser_type} #{compressor_type} Capacity = #{capacity_tons.round}tons; COP = #{cop} (#{kw_per_ton.round(1)}kW/ton)")
     
     return true
 

--- a/create_DOE_prototype_building/resources/Standards.CoilCoolingDXSingleSpeed.rb
+++ b/create_DOE_prototype_building/resources/Standards.CoilCoolingDXSingleSpeed.rb
@@ -5,148 +5,148 @@ class OpenStudio::Model::CoilCoolingDXSingleSpeed
 
   def setStandardEfficiencyAndCurves(template, hvac_standards)
   
-    unitary_acs = hvac_standards["unitary_acs"]
-    curve_biquadratics = hvac_standards["curve_biquadratics"]
-    curve_quadratics = hvac_standards["curve_quadratics"]
-    curve_bicubics = hvac_standards["curve_bicubics"]
-    curve_cubics = hvac_standards["curve_cubics"]
+    unitary_acs = hvac_standards['unitary_acs']
+    curve_biquadratics = hvac_standards['curve_biquadratics']
+    curve_quadratics = hvac_standards['curve_quadratics']
+    curve_bicubics = hvac_standards['curve_bicubics']
+    curve_cubics = hvac_standards['curve_cubics']
   
     # Define the criteria to find the chiller properties
     # in the hvac standards data set.
     search_criteria = {}
-    search_criteria["template"] = template
+    search_criteria['template'] = template
     cooling_type = self.condenserType
-    search_criteria["cooling_type"] = cooling_type
+    search_criteria['cooling_type'] = cooling_type
     
     # Determine the heating type
     # TODO deal with zone hvac and unitary equipment
     return false if self.airLoopHVAC.empty?
     air_loop = self.airLoopHVAC.get
     heating_type = nil
-    if air_loop.supplyComponents("Coil:Heating:Electric".to_IddObjectType).size > 0
-      heating_type = "Electric Resistance or None"
-    elsif air_loop.supplyComponents("Coil:Heating:Gas".to_IddObjectType).size > 0
-      heating_type = "All Other"
-    elsif air_loop.supplyComponents("Coil:Heating:Water".to_IddObjectType).size > 0
-      heating_type = "All Other"
-    elsif air_loop.supplyComponents("Coil:Heating:DX:SingleSpeed".to_IddObjectType).size > 0
-      heating_type = "All Other"
-    elsif air_loop.supplyComponents("Coil:Heating:Gas:MultiStage".to_IddObjectType).size > 0
-      heating_type = "All Other"
-    elsif air_loop.supplyComponents("Coil:Heating:Desuperheater".to_IddObjectType).size > 0
-      heating_type = "All Other"
-    elsif air_loop.supplyComponents("Coil:Heating:WaterToAirHeatPump:EquationFit".to_IddObjectType).size > 0
-      heating_type = "All Other"  
+    if air_loop.supplyComponents('Coil:Heating:Electric'.to_IddObjectType).size > 0
+      heating_type = 'Electric Resistance or None'
+    elsif air_loop.supplyComponents('Coil:Heating:Gas'.to_IddObjectType).size > 0
+      heating_type = 'All Other'
+    elsif air_loop.supplyComponents('Coil:Heating:Water'.to_IddObjectType).size > 0
+      heating_type = 'All Other'
+    elsif air_loop.supplyComponents('Coil:Heating:DX:SingleSpeed'.to_IddObjectType).size > 0
+      heating_type = 'All Other'
+    elsif air_loop.supplyComponents('Coil:Heating:Gas:MultiStage'.to_IddObjectType).size > 0
+      heating_type = 'All Other'
+    elsif air_loop.supplyComponents('Coil:Heating:Desuperheater'.to_IddObjectType).size > 0
+      heating_type = 'All Other'
+    elsif air_loop.supplyComponents('Coil:Heating:WaterToAirHeatPump:EquationFit'.to_IddObjectType).size > 0
+      heating_type = 'All Other'
     else
-      heating_type = "Electric Resistance or None"
+      heating_type = 'Electric Resistance or None'
     end
     unless heating_type.nil?
-      search_criteria["heating_type"] = heating_type
+      search_criteria['heating_type'] = heating_type
     end
     
     # TODO Standards - add split system vs single package to model
     # For now, assume single package
-    subcategory = "Single Package"
-    search_criteria["subcategory"] = subcategory
+    subcategory = 'Single Package'
+    search_criteria['subcategory'] = subcategory
 
     # Get the coil capacity and convert to Btu/hr
     return false if self.ratedTotalCoolingCapacity.empty?
     capacity_w = self.ratedTotalCoolingCapacity.get
-    capacity_btu_per_hr = OpenStudio.convert(capacity_w, "W", "Btu/hr").get
-    capacity_kbtu_per_hr = OpenStudio.convert(capacity_w, "W", "kBtu/hr").get
+    capacity_btu_per_hr = OpenStudio.convert(capacity_w, 'W', 'Btu/hr').get
+    capacity_kbtu_per_hr = OpenStudio.convert(capacity_w, 'W', 'kBtu/hr').get
     
     ac_props = find_object(unitary_acs, search_criteria, capacity_btu_per_hr)
     return false if ac_props.nil?
 
     # Make the COOL-CAP-FT curve
-    cool_cap_ft_data = find_object(curve_biquadratics, {"name"=>ac_props["cool_cap_ft"]})
+    cool_cap_ft_data = find_object(curve_biquadratics, {'name'=>ac_props['cool_cap_ft']})
     return false if cool_cap_ft_data.nil?
     cool_cap_ft = OpenStudio::Model::CurveBiquadratic.new(self.model)
     self.setTotalCoolingCapacityFunctionOfTemperatureCurve(cool_cap_ft)
-    cool_cap_ft.setName(cool_cap_ft_data["name"])
-    cool_cap_ft.setCoefficient1Constant(cool_cap_ft_data["coeff_1"])
-    cool_cap_ft.setCoefficient2x(cool_cap_ft_data["coeff_2"])
-    cool_cap_ft.setCoefficient3xPOW2(cool_cap_ft_data["coeff_3"])
-    cool_cap_ft.setCoefficient4y(cool_cap_ft_data["coeff_4"])
-    cool_cap_ft.setCoefficient5yPOW2(cool_cap_ft_data["coeff_5"])
-    cool_cap_ft.setCoefficient6xTIMESY(cool_cap_ft_data["coeff_6"])
-    cool_cap_ft.setMinimumValueofx(cool_cap_ft_data["min_x"])
-    cool_cap_ft.setMaximumValueofx(cool_cap_ft_data["max_x"])
-    cool_cap_ft.setMinimumValueofy(cool_cap_ft_data["min_y"])
-    cool_cap_ft.setMaximumValueofy(cool_cap_ft_data["max_y"])
+    cool_cap_ft.setName(cool_cap_ft_data['name'])
+    cool_cap_ft.setCoefficient1Constant(cool_cap_ft_data['coeff_1'])
+    cool_cap_ft.setCoefficient2x(cool_cap_ft_data['coeff_2'])
+    cool_cap_ft.setCoefficient3xPOW2(cool_cap_ft_data['coeff_3'])
+    cool_cap_ft.setCoefficient4y(cool_cap_ft_data['coeff_4'])
+    cool_cap_ft.setCoefficient5yPOW2(cool_cap_ft_data['coeff_5'])
+    cool_cap_ft.setCoefficient6xTIMESY(cool_cap_ft_data['coeff_6'])
+    cool_cap_ft.setMinimumValueofx(cool_cap_ft_data['min_x'])
+    cool_cap_ft.setMaximumValueofx(cool_cap_ft_data['max_x'])
+    cool_cap_ft.setMinimumValueofy(cool_cap_ft_data['min_y'])
+    cool_cap_ft.setMaximumValueofy(cool_cap_ft_data['max_y'])
 
     # Make the COOL-CAP-FFLOW curve
-    cool_cap_fflow_data = find_object(curve_cubics, {"name"=>ac_props["cool_cap_fflow"]})
+    cool_cap_fflow_data = find_object(curve_cubics, {'name'=>ac_props['cool_cap_fflow']})
     return false if cool_cap_fflow_data.nil?
     cool_cap_fflow = OpenStudio::Model::CurveCubic.new(self.model)
     self.setTotalCoolingCapacityFunctionOfFlowFractionCurve(cool_cap_fflow)
-    cool_cap_fflow.setName(cool_cap_fflow_data["name"])
-    cool_cap_fflow.setCoefficient1Constant(cool_cap_fflow_data["coeff_1"])
-    cool_cap_fflow.setCoefficient2x(cool_cap_fflow_data["coeff_2"])
-    cool_cap_fflow.setCoefficient3xPOW2(cool_cap_fflow_data["coeff_3"])
-    cool_cap_fflow.setCoefficient4xPOW3(cool_cap_fflow_data["coeff_4"])
-    cool_cap_fflow.setMinimumValueofx(cool_cap_fflow_data["min_x"])
-    cool_cap_fflow.setMaximumValueofx(cool_cap_fflow_data["max_x"])
+    cool_cap_fflow.setName(cool_cap_fflow_data['name'])
+    cool_cap_fflow.setCoefficient1Constant(cool_cap_fflow_data['coeff_1'])
+    cool_cap_fflow.setCoefficient2x(cool_cap_fflow_data['coeff_2'])
+    cool_cap_fflow.setCoefficient3xPOW2(cool_cap_fflow_data['coeff_3'])
+    cool_cap_fflow.setCoefficient4xPOW3(cool_cap_fflow_data['coeff_4'])
+    cool_cap_fflow.setMinimumValueofx(cool_cap_fflow_data['min_x'])
+    cool_cap_fflow.setMaximumValueofx(cool_cap_fflow_data['max_x'])
     
     # Make the COOL-EIR-FT curve
-    cool_eir_ft_data = find_object(curve_biquadratics, {"name"=>ac_props["cool_eir_ft"]})
+    cool_eir_ft_data = find_object(curve_biquadratics, {'name'=>ac_props['cool_eir_ft']})
     return false if cool_eir_ft_data.nil?
     cool_eir_ft = OpenStudio::Model::CurveBiquadratic.new(self.model)
     self.setEnergyInputRatioFunctionOfTemperatureCurve(cool_eir_ft)
-    cool_eir_ft.setName(cool_eir_ft_data["name"])
-    cool_eir_ft.setCoefficient1Constant(cool_eir_ft_data["coeff_1"])
-    cool_eir_ft.setCoefficient2x(cool_eir_ft_data["coeff_2"])
-    cool_eir_ft.setCoefficient3xPOW2(cool_eir_ft_data["coeff_3"])
-    cool_eir_ft.setCoefficient4y(cool_eir_ft_data["coeff_4"])
-    cool_eir_ft.setCoefficient5yPOW2(cool_eir_ft_data["coeff_5"])
-    cool_eir_ft.setCoefficient6xTIMESY(cool_eir_ft_data["coeff_6"])
-    cool_eir_ft.setMinimumValueofx(cool_eir_ft_data["min_x"])
-    cool_eir_ft.setMaximumValueofx(cool_eir_ft_data["max_x"])
-    cool_eir_ft.setMinimumValueofy(cool_eir_ft_data["min_y"])
-    cool_eir_ft.setMaximumValueofy(cool_eir_ft_data["max_y"])    
+    cool_eir_ft.setName(cool_eir_ft_data['name'])
+    cool_eir_ft.setCoefficient1Constant(cool_eir_ft_data['coeff_1'])
+    cool_eir_ft.setCoefficient2x(cool_eir_ft_data['coeff_2'])
+    cool_eir_ft.setCoefficient3xPOW2(cool_eir_ft_data['coeff_3'])
+    cool_eir_ft.setCoefficient4y(cool_eir_ft_data['coeff_4'])
+    cool_eir_ft.setCoefficient5yPOW2(cool_eir_ft_data['coeff_5'])
+    cool_eir_ft.setCoefficient6xTIMESY(cool_eir_ft_data['coeff_6'])
+    cool_eir_ft.setMinimumValueofx(cool_eir_ft_data['min_x'])
+    cool_eir_ft.setMaximumValueofx(cool_eir_ft_data['max_x'])
+    cool_eir_ft.setMinimumValueofy(cool_eir_ft_data['min_y'])
+    cool_eir_ft.setMaximumValueofy(cool_eir_ft_data['max_y'])
     
     # Make the COOL-EIR-FFLOW curve
-    cool_eir_fflow_data = find_object(curve_cubics, {"name"=>ac_props["cool_eir_fflow"]})
+    cool_eir_fflow_data = find_object(curve_cubics, {'name'=>ac_props['cool_eir_fflow']})
     return false if cool_eir_fflow_data.nil?
     cool_eir_fflow = OpenStudio::Model::CurveCubic.new(self.model)
     self.setEnergyInputRatioFunctionOfFlowFractionCurve(cool_eir_fflow)
-    cool_eir_fflow.setName(cool_eir_fflow_data["name"])
-    cool_eir_fflow.setCoefficient1Constant(cool_eir_fflow_data["coeff_1"])
-    cool_eir_fflow.setCoefficient2x(cool_eir_fflow_data["coeff_2"])
-    cool_eir_fflow.setCoefficient3xPOW2(cool_eir_fflow_data["coeff_3"])
-    cool_eir_fflow.setCoefficient4xPOW3(cool_eir_fflow_data["coeff_4"])
-    cool_eir_fflow.setMinimumValueofx(cool_eir_fflow_data["min_x"])
-    cool_eir_fflow.setMaximumValueofx(cool_eir_fflow_data["max_x"])
+    cool_eir_fflow.setName(cool_eir_fflow_data['name'])
+    cool_eir_fflow.setCoefficient1Constant(cool_eir_fflow_data['coeff_1'])
+    cool_eir_fflow.setCoefficient2x(cool_eir_fflow_data['coeff_2'])
+    cool_eir_fflow.setCoefficient3xPOW2(cool_eir_fflow_data['coeff_3'])
+    cool_eir_fflow.setCoefficient4xPOW3(cool_eir_fflow_data['coeff_4'])
+    cool_eir_fflow.setMinimumValueofx(cool_eir_fflow_data['min_x'])
+    cool_eir_fflow.setMaximumValueofx(cool_eir_fflow_data['max_x'])
     
     # Make the COOL-PLF-FPLR curve
-    cool_plf_fplr_data = find_object(curve_quadratics, {"name"=>ac_props["cool_plf_fplr"]})
+    cool_plf_fplr_data = find_object(curve_quadratics, {'name'=>ac_props['cool_plf_fplr']})
     return false if cool_plf_fplr_data.nil?
     cool_plf_fplr = OpenStudio::Model::CurveQuadratic.new(self.model)
     self.setPartLoadFractionCorrelationCurve(cool_plf_fplr)
-    cool_plf_fplr.setName(cool_plf_fplr_data["name"])
-    cool_plf_fplr.setCoefficient1Constant(cool_plf_fplr_data["coeff_1"])
-    cool_plf_fplr.setCoefficient2x(cool_plf_fplr_data["coeff_2"])
-    cool_plf_fplr.setCoefficient3xPOW2(cool_plf_fplr_data["coeff_3"])
-    cool_plf_fplr.setMinimumValueofx(cool_plf_fplr_data["min_x"])
-    cool_plf_fplr.setMaximumValueofx(cool_plf_fplr_data["max_x"])
+    cool_plf_fplr.setName(cool_plf_fplr_data['name'])
+    cool_plf_fplr.setCoefficient1Constant(cool_plf_fplr_data['coeff_1'])
+    cool_plf_fplr.setCoefficient2x(cool_plf_fplr_data['coeff_2'])
+    cool_plf_fplr.setCoefficient3xPOW2(cool_plf_fplr_data['coeff_3'])
+    cool_plf_fplr.setMinimumValueofx(cool_plf_fplr_data['min_x'])
+    cool_plf_fplr.setMaximumValueofx(cool_plf_fplr_data['max_x'])
     
     # Get the minimum efficiency standards
     cop = nil
     
     # If specified as SEER
-    unless ac_props["minimum_seer"].nil?
-      min_seer = ac_props["minimum_seer"]
+    unless ac_props['minimum_seer'].nil?
+      min_seer = ac_props['minimum_seer']
       cop = seer_to_cop(min_seer)
       self.setName("#{self.name} #{capacity_kbtu_per_hr.round}kBtu/hr #{min_seer}SEER")
-      OpenStudio::logFree(OpenStudio::Info, "openstudio.hvac_standards.CoilCoolingDXSingleSpeed",  "For #{template}: #{self.name}: #{cooling_type} #{heating_type} #{subcategory} Capacity = #{capacity_kbtu_per_hr.round}kBtu/hr; SEER = #{min_seer}")  
+      OpenStudio::logFree(OpenStudio::Info, 'openstudio.hvac_standards.CoilCoolingDXSingleSpeed',  "For #{template}: #{self.name}: #{cooling_type} #{heating_type} #{subcategory} Capacity = #{capacity_kbtu_per_hr.round}kBtu/hr; SEER = #{min_seer}")
     end
     
     # If specified as EER
-    unless ac_props["minimum_eer"].nil?
-      min_eer = ac_props["minimum_eer"]
+    unless ac_props['minimum_eer'].nil?
+      min_eer = ac_props['minimum_eer']
       cop = eer_to_cop(min_eer)
       self.setName("#{self.name} #{capacity_kbtu_per_hr.round}kBtu/hr #{min_eer}EER")
-      OpenStudio::logFree(OpenStudio::Info, "openstudio.hvac_standards.CoilCoolingDXSingleSpeed", "For #{template}: #{self.name}: #{cooling_type} #{heating_type} #{subcategory} Capacity = #{capacity_kbtu_per_hr.round}kBtu/hr; EER = #{min_eer}")
+      OpenStudio::logFree(OpenStudio::Info, 'openstudio.hvac_standards.CoilCoolingDXSingleSpeed', "For #{template}: #{self.name}: #{cooling_type} #{heating_type} #{subcategory} Capacity = #{capacity_kbtu_per_hr.round}kBtu/hr; EER = #{min_eer}")
     end
 
     # Set the efficiency values

--- a/create_DOE_prototype_building/resources/Standards.CoilCoolingDXTwoSpeed.rb
+++ b/create_DOE_prototype_building/resources/Standards.CoilCoolingDXTwoSpeed.rb
@@ -4,123 +4,123 @@ class OpenStudio::Model::CoilCoolingDXTwoSpeed
 
   def setStandardEfficiencyAndCurves(template, hvac_standards)
   
-    unitary_acs = hvac_standards["unitary_acs"]
-    #curve_biquadratics = hvac_standards["curve_biquadratics"]
-    #curve_quadratics = hvac_standards["curve_quadratics"]
-    #curve_bicubics = hvac_standards["curve_bicubics"]
+    unitary_acs = hvac_standards['unitary_acs']
+    #curve_biquadratics = hvac_standards['curve_biquadratics']
+    #curve_quadratics = hvac_standards['curve_quadratics']
+    #curve_bicubics = hvac_standards['curve_bicubics']
   
     # Define the criteria to find the chiller properties
     # in the hvac standards data set.
     search_criteria = {}
-    search_criteria["template"] = template
+    search_criteria['template'] = template
     cooling_type = self.condenserType
-    search_criteria["cooling_type"] = cooling_type
+    search_criteria['cooling_type'] = cooling_type
     
     # Determine the heating type
     # TODO deal with zone hvac and unitary equipment
     return false if self.airLoopHVAC.empty?
     air_loop = self.airLoopHVAC.get
     heating_type = nil
-    if air_loop.supplyComponents("Coil:Heating:Electric".to_IddObjectType).size > 0
-      heating_type = "Electric Resistance or None"
-    elsif air_loop.supplyComponents("Coil:Heating:Gas".to_IddObjectType).size > 0
-      heating_type = "All Other"
-    elsif air_loop.supplyComponents("Coil:Heating:Water".to_IddObjectType).size > 0
-      heating_type = "All Other"
-    elsif air_loop.supplyComponents("Coil:Heating:DX:SingleSpeed".to_IddObjectType).size > 0
-      heating_type = "All Other"
-    elsif air_loop.supplyComponents("Coil:Heating:Gas:MultiStage".to_IddObjectType).size > 0
-      heating_type = "All Other"
-    elsif air_loop.supplyComponents("Coil:Heating:Desuperheater".to_IddObjectType).size > 0
-      heating_type = "All Other"
-    elsif air_loop.supplyComponents("Coil:Heating:WaterToAirHeatPump:EquationFit".to_IddObjectType).size > 0
-      heating_type = "All Other"  
+    if air_loop.supplyComponents('Coil:Heating:Electric'.to_IddObjectType).size > 0
+      heating_type = 'Electric Resistance or None'
+    elsif air_loop.supplyComponents('Coil:Heating:Gas'.to_IddObjectType).size > 0
+      heating_type = 'All Other'
+    elsif air_loop.supplyComponents('Coil:Heating:Water'.to_IddObjectType).size > 0
+      heating_type = 'All Other'
+    elsif air_loop.supplyComponents('Coil:Heating:DX:SingleSpeed'.to_IddObjectType).size > 0
+      heating_type = 'All Other'
+    elsif air_loop.supplyComponents('Coil:Heating:Gas:MultiStage'.to_IddObjectType).size > 0
+      heating_type = 'All Other'
+    elsif air_loop.supplyComponents('Coil:Heating:Desuperheater'.to_IddObjectType).size > 0
+      heating_type = 'All Other'
+    elsif air_loop.supplyComponents('Coil:Heating:WaterToAirHeatPump:EquationFit'.to_IddObjectType).size > 0
+      heating_type = 'All Other'
     else
-      heating_type = "Electric Resistance or None"
+      heating_type = 'Electric Resistance or None'
     end
     unless heating_type.nil?
-      search_criteria["heating_type"] = heating_type
+      search_criteria['heating_type'] = heating_type
     end
     
     # TODO Standards - add split system vs single package to model
     # For now, assume single package
-    subcategory = "Single Package"
-    search_criteria["subcategory"] = subcategory
+    subcategory = 'Single Package'
+    search_criteria['subcategory'] = subcategory
 
     # Get the coil capacity and convert to Btu/hr
     return false if self.ratedHighSpeedTotalCoolingCapacity.empty?
     capacity_w = self.ratedHighSpeedTotalCoolingCapacity.get
-    capacity_btu_per_hr = OpenStudio.convert(capacity_w, "W", "Btu/hr").get
-    capacity_kbtu_per_hr = OpenStudio.convert(capacity_w, "W", "kBtu/hr").get
+    capacity_btu_per_hr = OpenStudio.convert(capacity_w, 'W', 'Btu/hr').get
+    capacity_kbtu_per_hr = OpenStudio.convert(capacity_w, 'W', 'kBtu/hr').get
     
     
     ac_props = find_object(unitary_acs, search_criteria, capacity_btu_per_hr)
     return false if ac_props.nil?
 =begin
     # Make the CAPFT curve
-    capft_properties = find_object(curve_biquadratics, {"name"=>ac_props["capft"]})
+    capft_properties = find_object(curve_biquadratics, {'name'=>ac_props['capft']})
     return false if capft_properties.nil?
     ccFofT = self.coolingCapacityFunctionOfTemperature
-    ccFofT.setName(capft_properties["name"])
-    ccFofT.setCoefficient1Constant(capft_properties["coeff_1"])
-    ccFofT.setCoefficient2x(capft_properties["coeff_2"])
-    ccFofT.setCoefficient3xPOW2(capft_properties["coeff_3"])
-    ccFofT.setCoefficient4y(capft_properties["coeff_4"])
-    ccFofT.setCoefficient5yPOW2(capft_properties["coeff_5"])
-    ccFofT.setCoefficient6xTIMESY(capft_properties["coeff_6"])
-    ccFofT.setMinimumValueofx(capft_properties["min_x"])
-    ccFofT.setMaximumValueofx(capft_properties["max_x"])
-    ccFofT.setMinimumValueofy(capft_properties["min_y"])
-    ccFofT.setMaximumValueofy(capft_properties["max_y"])
+    ccFofT.setName(capft_properties['name'])
+    ccFofT.setCoefficient1Constant(capft_properties['coeff_1'])
+    ccFofT.setCoefficient2x(capft_properties['coeff_2'])
+    ccFofT.setCoefficient3xPOW2(capft_properties['coeff_3'])
+    ccFofT.setCoefficient4y(capft_properties['coeff_4'])
+    ccFofT.setCoefficient5yPOW2(capft_properties['coeff_5'])
+    ccFofT.setCoefficient6xTIMESY(capft_properties['coeff_6'])
+    ccFofT.setMinimumValueofx(capft_properties['min_x'])
+    ccFofT.setMaximumValueofx(capft_properties['max_x'])
+    ccFofT.setMinimumValueofy(capft_properties['min_y'])
+    ccFofT.setMaximumValueofy(capft_properties['max_y'])
 
     # Make the EIRFT curve
-    eirft_properties = find_object(curve_biquadratics, {"name"=>ac_props["eirft"]})
+    eirft_properties = find_object(curve_biquadratics, {'name'=>ac_props['eirft']})
     return false if eirft_properties.nil?
     eirToCorfOfT = self.electricInputToCoolingOutputRatioFunctionOfTemperature
-    eirToCorfOfT.setName(eirft_properties["name"])
-    eirToCorfOfT.setCoefficient1Constant(eirft_properties["coeff_1"])
-    eirToCorfOfT.setCoefficient2x(eirft_properties["coeff_2"])
-    eirToCorfOfT.setCoefficient3xPOW2(eirft_properties["coeff_3"])
-    eirToCorfOfT.setCoefficient4y(eirft_properties["coeff_4"])
-    eirToCorfOfT.setCoefficient5yPOW2(eirft_properties["coeff_5"])
-    eirToCorfOfT.setCoefficient6xTIMESY(eirft_properties["coeff_6"])
-    eirToCorfOfT.setMinimumValueofx(eirft_properties["min_x"])
-    eirToCorfOfT.setMaximumValueofx(eirft_properties["max_x"])
-    eirToCorfOfT.setMinimumValueofy(eirft_properties["min_y"])
-    eirToCorfOfT.setMaximumValueofy(eirft_properties["max_y"])
+    eirToCorfOfT.setName(eirft_properties['name'])
+    eirToCorfOfT.setCoefficient1Constant(eirft_properties['coeff_1'])
+    eirToCorfOfT.setCoefficient2x(eirft_properties['coeff_2'])
+    eirToCorfOfT.setCoefficient3xPOW2(eirft_properties['coeff_3'])
+    eirToCorfOfT.setCoefficient4y(eirft_properties['coeff_4'])
+    eirToCorfOfT.setCoefficient5yPOW2(eirft_properties['coeff_5'])
+    eirToCorfOfT.setCoefficient6xTIMESY(eirft_properties['coeff_6'])
+    eirToCorfOfT.setMinimumValueofx(eirft_properties['min_x'])
+    eirToCorfOfT.setMaximumValueofx(eirft_properties['max_x'])
+    eirToCorfOfT.setMinimumValueofy(eirft_properties['min_y'])
+    eirToCorfOfT.setMaximumValueofy(eirft_properties['max_y'])
 
     # Make the EIRFPLR curve
     # which may be either a CurveBicubic or a CurveQuadratic based on chiller type
     eirToCorfOfPlr = nil
-    eirfplr_properties = find_object(curve_quadratics, {"name"=>ac_props["eirfplr"]})
+    eirfplr_properties = find_object(curve_quadratics, {'name'=>ac_props['eirfplr']})
     if eirfplr_properties
       eirToCorfOfPlr = OpenStudio::Model::CurveQuadratic.new(self.model)
-      eirToCorfOfPlr.setName(eirfplr_properties["name"])
-      eirToCorfOfPlr.setCoefficient1Constant(eirfplr_properties["coeff_1"])
-      eirToCorfOfPlr.setCoefficient2x(eirfplr_properties["coeff_2"])
-      eirToCorfOfPlr.setCoefficient3xPOW2(eirfplr_properties["coeff_3"])
-      eirToCorfOfPlr.setMinimumValueofx(eirfplr_properties["min_x"])
-      eirToCorfOfPlr.setMaximumValueofx(eirfplr_properties["max_x"])
+      eirToCorfOfPlr.setName(eirfplr_properties['name'])
+      eirToCorfOfPlr.setCoefficient1Constant(eirfplr_properties['coeff_1'])
+      eirToCorfOfPlr.setCoefficient2x(eirfplr_properties['coeff_2'])
+      eirToCorfOfPlr.setCoefficient3xPOW2(eirfplr_properties['coeff_3'])
+      eirToCorfOfPlr.setMinimumValueofx(eirfplr_properties['min_x'])
+      eirToCorfOfPlr.setMaximumValueofx(eirfplr_properties['max_x'])
     end
     
-    eirfplr_properties = find_object(curve_bicubics, {"name"=>ac_props["eirfplr"]})
+    eirfplr_properties = find_object(curve_bicubics, {'name'=>ac_props['eirfplr']})
     if eirfplr_properties
       eirToCorfOfPlr = OpenStudio::Model::CurveBicubic.new(self.model)
-      eirToCorfOfPlr.setName(eirft_properties["name"])
-      eirToCorfOfPlr.setCoefficient1Constant(eirfplr_properties["coeff_1"])
-      eirToCorfOfPlr.setCoefficient2x(eirfplr_properties["coeff_2"])
-      eirToCorfOfPlr.setCoefficient3xPOW2(eirfplr_properties["coeff_3"])
-      eirToCorfOfPlr.setCoefficient4y(eirfplr_properties["coeff_4"])
-      eirToCorfOfPlr.setCoefficient5yPOW2(eirfplr_properties["coeff_5"])
-      eirToCorfOfPlr.setCoefficient6xTIMESY(eirfplr_properties["coeff_6"])
-      eirToCorfOfPlr.setCoefficient7xPOW3 (eirfplr_properties["coeff_7"])
-      eirToCorfOfPlr.setCoefficient8yPOW3 (eirfplr_properties["coeff_8"])
-      eirToCorfOfPlr.setCoefficient9xPOW2TIMESY(eirfplr_properties["coeff_9"])
-      eirToCorfOfPlr.setCoefficient10xTIMESYPOW2 (eirfplr_properties["coeff_10"])
-      eirToCorfOfPlr.setMinimumValueofx(eirft_properties["min_x"])
-      eirToCorfOfPlr.setMaximumValueofx(eirft_properties["max_x"])
-      eirToCorfOfPlr.setMinimumValueofy(eirft_properties["min_y"])
-      eirToCorfOfPlr.setMaximumValueofy(eirft_properties["max_y"])
+      eirToCorfOfPlr.setName(eirft_properties['name'])
+      eirToCorfOfPlr.setCoefficient1Constant(eirfplr_properties['coeff_1'])
+      eirToCorfOfPlr.setCoefficient2x(eirfplr_properties['coeff_2'])
+      eirToCorfOfPlr.setCoefficient3xPOW2(eirfplr_properties['coeff_3'])
+      eirToCorfOfPlr.setCoefficient4y(eirfplr_properties['coeff_4'])
+      eirToCorfOfPlr.setCoefficient5yPOW2(eirfplr_properties['coeff_5'])
+      eirToCorfOfPlr.setCoefficient6xTIMESY(eirfplr_properties['coeff_6'])
+      eirToCorfOfPlr.setCoefficient7xPOW3 (eirfplr_properties['coeff_7'])
+      eirToCorfOfPlr.setCoefficient8yPOW3 (eirfplr_properties['coeff_8'])
+      eirToCorfOfPlr.setCoefficient9xPOW2TIMESY(eirfplr_properties['coeff_9'])
+      eirToCorfOfPlr.setCoefficient10xTIMESYPOW2 (eirfplr_properties['coeff_10'])
+      eirToCorfOfPlr.setMinimumValueofx(eirft_properties['min_x'])
+      eirToCorfOfPlr.setMaximumValueofx(eirft_properties['max_x'])
+      eirToCorfOfPlr.setMinimumValueofy(eirft_properties['min_y'])
+      eirToCorfOfPlr.setMaximumValueofy(eirft_properties['max_y'])
     end  
 =end
 
@@ -128,19 +128,19 @@ class OpenStudio::Model::CoilCoolingDXTwoSpeed
     cop = nil
     
     # If specified as SEER
-    unless ac_props["minimum_seer"].nil?
-      min_seer = ac_props["minimum_seer"]
+    unless ac_props['minimum_seer'].nil?
+      min_seer = ac_props['minimum_seer']
       cop = seer_to_cop(min_seer)
       self.setName("#{self.name} #{capacity_kbtu_per_hr.round}kBtu/hr #{min_seer}SEER")
-      OpenStudio::logFree(OpenStudio::Info, "openstudio.model.CoilCoolingDXTwoSpeed", "For #{template}: #{self.name}: #{cooling_type} #{heating_type} #{subcategory} Capacity = #{capacity_kbtu_per_hr.round}kBtu/hr; SEER = #{min_seer}")
+      OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.CoilCoolingDXTwoSpeed', "For #{template}: #{self.name}: #{cooling_type} #{heating_type} #{subcategory} Capacity = #{capacity_kbtu_per_hr.round}kBtu/hr; SEER = #{min_seer}")
     end
     
     # If specified as EER
-    unless ac_props["minimum_eer"].nil?
-      min_eer = ac_props["minimum_eer"]
+    unless ac_props['minimum_eer'].nil?
+      min_eer = ac_props['minimum_eer']
       cop = eer_to_cop(min_eer)
       self.setName("#{self.name} #{capacity_kbtu_per_hr.round}kBtu/hr #{min_eer}EER")
-      OpenStudio::logFree(OpenStudio::Info, "openstudio.model.CoilCoolingDXTwoSpeed", "For #{template}: #{self.name}: #{cooling_type} #{heating_type} #{subcategory} Capacity = #{capacity_kbtu_per_hr.round}kBtu/hr; EER = #{min_eer}")
+      OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.CoilCoolingDXTwoSpeed', "For #{template}: #{self.name}: #{cooling_type} #{heating_type} #{subcategory} Capacity = #{capacity_kbtu_per_hr.round}kBtu/hr; EER = #{min_eer}")
     end
 
     # Set the efficiency values

--- a/create_DOE_prototype_building/resources/Standards.ConstructionSetGenerator.rb
+++ b/create_DOE_prototype_building/resources/Standards.ConstructionSetGenerator.rb
@@ -12,13 +12,13 @@ def initialize(path_to_standards_json)
   @standards = {}
   temp = File.read(path_to_standards_json.to_s)
   @standards = JSON.parse(temp)
-  @construction_sets = @standards["construction_sets"]
-  @constructions = @standards["constructions"]
-  @materials = @standards["materials"]
-  @climate_zone_sets = @standards["climate_zone_sets"]
-  @climate_zones = @standards["climate_zones"]
+  @construction_sets = @standards['construction_sets']
+  @constructions = @standards['constructions']
+  @materials = @standards['materials']
+  @climate_zone_sets = @standards['climate_zone_sets']
+  @climate_zones = @standards['climate_zones']
   if @construction_sets.nil? or @constructions.nil? or @materials.nil? or @climate_zone_sets.nil? or @climate_zones.nil?
-    puts "The standards json file did not load correctly."
+    puts 'The standards json file did not load correctly.'
     exit
   end
 
@@ -27,45 +27,45 @@ end
 
 def make_name(template, clim, building_type, spc_type)
 
-  clim = clim.gsub("ClimateZone ", "CZ")
-  if clim == "CZ1-8"
-    clim = ""
+  clim = clim.gsub('ClimateZone ', 'CZ')
+  if clim == 'CZ1-8'
+    clim = ''
   end
   
-  if building_type == "FullServiceRestaurant"
-    building_type = "FullSrvRest"
-  elsif building_type == "Hospital"
-    building_type = "Hospital"
-  elsif building_type == "LargeHotel"
-    building_type = "LrgHotel"
-  elsif building_type == "LargeOffice"
-    building_type = "LrgOffice"
-  elsif building_type == "MediumOffice"
-    building_type = "MedOffice"
-  elsif building_type == "Mid-riseApartment"
-    building_type = "MidApt"
-  elsif building_type == "Office"
-    building_type = "Office"
-  elsif building_type == "Outpatient"
-    building_type = "Outpatient"
-  elsif building_type == "PrimarySchool"
-    building_type = "PriSchl"
-  elsif building_type == "QuickServiceRestaurant"
-    building_type = "QckSrvRest"
-  elsif building_type == "Retail"
-    building_type = "Retail"
-  elsif building_type == "SecondarySchool"
-    building_type = "SecSchl"
-  elsif building_type == "SmallHotel"
-    building_type = "SmHotel"
-  elsif building_type == "SmallOffice"
-    building_type = "SmOffice"
-  elsif building_type == "StripMall"
-    building_type = "StMall"
-  elsif building_type == "SuperMarket"
-    building_type = "SpMarket"
-  elsif building_type == "Warehouse"
-    building_type = "Warehouse"
+  if building_type == 'FullServiceRestaurant'
+    building_type = 'FullSrvRest'
+  elsif building_type == 'Hospital'
+    building_type = 'Hospital'
+  elsif building_type == 'LargeHotel'
+    building_type = 'LrgHotel'
+  elsif building_type == 'LargeOffice'
+    building_type = 'LrgOffice'
+  elsif building_type == 'MediumOffice'
+    building_type = 'MedOffice'
+  elsif building_type == 'Mid-riseApartment'
+    building_type = 'MidApt'
+  elsif building_type == 'Office'
+    building_type = 'Office'
+  elsif building_type == 'Outpatient'
+    building_type = 'Outpatient'
+  elsif building_type == 'PrimarySchool'
+    building_type = 'PriSchl'
+  elsif building_type == 'QuickServiceRestaurant'
+    building_type = 'QckSrvRest'
+  elsif building_type == 'Retail'
+    building_type = 'Retail'
+  elsif building_type == 'SecondarySchool'
+    building_type = 'SecSchl'
+  elsif building_type == 'SmallHotel'
+    building_type = 'SmHotel'
+  elsif building_type == 'SmallOffice'
+    building_type = 'SmOffice'
+  elsif building_type == 'StripMall'
+    building_type = 'StMall'
+  elsif building_type == 'SuperMarket'
+    building_type = 'SpMarket'
+  elsif building_type == 'Warehouse'
+    building_type = 'Warehouse'
   end
   
   parts = [template]
@@ -97,71 +97,71 @@ end
 def make_material(material_name, data, model)  
 
   material = nil
-  material_type = data["material_type"]
+  material_type = data['material_type']
   
-  if material_type == "StandardOpaqueMaterial"
+  if material_type == 'StandardOpaqueMaterial'
     material = OpenStudio::Model::StandardOpaqueMaterial.new(model)
     material.setName(material_name)
     
-    material.setRoughness(data["roughness"].to_s)
-    material.setThickness(OpenStudio::convert(data["thickness"].to_f, "in", "m").get)
-    material.setConductivity(OpenStudio::convert(data["conductivity"].to_f, "Btu*in/hr*ft^2*R", "W/m*K").get)
-    material.setDensity(OpenStudio::convert(data["density"].to_f, "lb/ft^3", "kg/m^3").get)
-    material.setSpecificHeat(OpenStudio::convert(data["specific_heat"].to_f, "Btu/lb*R", "J/kg*K").get)
-    material.setThermalAbsorptance(data["thermal_absorptance"].to_f)
-    material.setSolarAbsorptance(data["solar_absorptance"].to_f)
-    material.setVisibleAbsorptance(data["visible_absorptance"].to_f)
+    material.setRoughness(data['roughness'].to_s)
+    material.setThickness(OpenStudio::convert(data['thickness'].to_f, 'in', 'm').get)
+    material.setConductivity(OpenStudio::convert(data['conductivity'].to_f, 'Btu*in/hr*ft^2*R', 'W/m*K').get)
+    material.setDensity(OpenStudio::convert(data['density'].to_f, 'lb/ft^3', 'kg/m^3').get)
+    material.setSpecificHeat(OpenStudio::convert(data['specific_heat'].to_f, 'Btu/lb*R', 'J/kg*K').get)
+    material.setThermalAbsorptance(data['thermal_absorptance'].to_f)
+    material.setSolarAbsorptance(data['solar_absorptance'].to_f)
+    material.setVisibleAbsorptance(data['visible_absorptance'].to_f)
     
-  elsif material_type == "MasslessOpaqueMaterial" 
+  elsif material_type == 'MasslessOpaqueMaterial'
     material = OpenStudio::Model::MasslessOpaqueMaterial.new(model)
     material.setName(material_name)
     
-    material.setConductivity(OpenStudio::convert(data["conductivity"].to_f, "Btu*in/hr*ft^2*R", "W/m*K").get)
-    material.setDensity(OpenStudio::convert(data["density"].to_f, "lb/ft^3", "kg/m^3").get)
-    material.setSpecificHeat(OpenStudio::convert(data["specific_heat"].to_f, "Btu/lb*R", "J/kg*K").get)
-    material.setThermalAbsorptance(data["thermal_absorptance"].to_f)
-    material.setSolarAbsorptance(data["solar_absorptance"].to_f)
-    material.setVisibleAbsorptance(data["visible_absorptance"].to_f)
+    material.setConductivity(OpenStudio::convert(data['conductivity'].to_f, 'Btu*in/hr*ft^2*R', 'W/m*K').get)
+    material.setDensity(OpenStudio::convert(data['density'].to_f, 'lb/ft^3', 'kg/m^3').get)
+    material.setSpecificHeat(OpenStudio::convert(data['specific_heat'].to_f, 'Btu/lb*R', 'J/kg*K').get)
+    material.setThermalAbsorptance(data['thermal_absorptance'].to_f)
+    material.setSolarAbsorptance(data['solar_absorptance'].to_f)
+    material.setVisibleAbsorptance(data['visible_absorptance'].to_f)
     
-  elsif material_type == "AirGap"
+  elsif material_type == 'AirGap'
     material = OpenStudio::Model::AirGap.new(model)
     material.setName(material_name)
     
-    material.setThermalResistance(OpenStudio::convert(data["resistance"].to_f, "hr*ft^2*R/Btu*in", "m*K/W").get)
+    material.setThermalResistance(OpenStudio::convert(data['resistance'].to_f, 'hr*ft^2*R/Btu*in', 'm*K/W').get)
 
-  elsif material_type == "Gas"
+  elsif material_type == 'Gas'
     material = OpenStudio::Model::Gas.new(model)
     material.setName(material_name)
 
-    material.setThickness(OpenStudio::convert(data["thickness"].to_f, "in", "m").get)
-    material.setGasType(data["gas_type"].to_s)
+    material.setThickness(OpenStudio::convert(data['thickness'].to_f, 'in', 'm').get)
+    material.setGasType(data['gas_type'].to_s)
     
-  elsif material_type == "SimpleGlazing" 
+  elsif material_type == 'SimpleGlazing'
     material = OpenStudio::Model::SimpleGlazing.new(model)
     material.setName(material_name)
     
-    material.setUFactor(OpenStudio::convert(data["u_factor"].to_f, "Btu/hr*ft^2*R", "W/m^2*K").get)
-    material.setSolarHeatGainCoefficient(data["solar_heat_gain_coefficient"].to_f)
-    material.setVisibleTransmittance(data["visible_transmittance"].to_f)
+    material.setUFactor(OpenStudio::convert(data['u_factor'].to_f, 'Btu/hr*ft^2*R', 'W/m^2*K').get)
+    material.setSolarHeatGainCoefficient(data['solar_heat_gain_coefficient'].to_f)
+    material.setVisibleTransmittance(data['visible_transmittance'].to_f)
 
-  elsif material_type == "StandardGlazing" 
+  elsif material_type == 'StandardGlazing'
     material = OpenStudio::Model::StandardGlazing.new(model)
     material.setName(material_name)
     
-    material.setOpticalDataType(data["optical_data_type"].to_s)
-    material.setThickness(OpenStudio::convert(data["thickness"].to_f, "in", "m").get)
-    material.setSolarTransmittanceatNormalIncidence(data["solar_transmittance_at_normal_incidence"].to_f)
-    material.setFrontSideSolarReflectanceatNormalIncidence(data["front_side_solar_reflectance_at_normal_incidence"].to_f)
-    material.setBackSideSolarReflectanceatNormalIncidence(data["back_side_solar_reflectance_at_normal_incidence"].to_f)
-    material.setVisibleTransmittanceatNormalIncidence(data["visible_transmittance_at_normal_incidence"].to_f)
-    material.setFrontSideVisibleReflectanceatNormalIncidence(data["front_side_visible_reflectance_at_normal_incidence"].to_f)
-    material.setBackSideVisibleReflectanceatNormalIncidence(data["back_side_visible_reflectance_at_normal_incidence"].to_f)
-    material.setInfraredTransmittanceatNormalIncidence(data["infrared_transmittance_at_normal_incidence"].to_f)
-    material.setFrontSideInfraredHemisphericalEmissivity(data["front_side_infrared_hemispherical_emissivity"].to_f)
-    material.setBackSideInfraredHemisphericalEmissivity(data["back_side_infrared_hemispherical_emissivity"].to_f) 
-    material.setConductivity(OpenStudio::convert(data["conductivity"].to_f, "Btu*in/hr*ft^2*R", "W/m*K").get)
-    material.setDirtCorrectionFactorforSolarandVisibleTransmittance(data["dirt_correction_factor_for_solar_and_visible_transmittance"].to_f) 
-    if /true/i.match(data["solar_diffusing"].to_s)
+    material.setOpticalDataType(data['optical_data_type'].to_s)
+    material.setThickness(OpenStudio::convert(data['thickness'].to_f, 'in', 'm').get)
+    material.setSolarTransmittanceatNormalIncidence(data['solar_transmittance_at_normal_incidence'].to_f)
+    material.setFrontSideSolarReflectanceatNormalIncidence(data['front_side_solar_reflectance_at_normal_incidence'].to_f)
+    material.setBackSideSolarReflectanceatNormalIncidence(data['back_side_solar_reflectance_at_normal_incidence'].to_f)
+    material.setVisibleTransmittanceatNormalIncidence(data['visible_transmittance_at_normal_incidence'].to_f)
+    material.setFrontSideVisibleReflectanceatNormalIncidence(data['front_side_visible_reflectance_at_normal_incidence'].to_f)
+    material.setBackSideVisibleReflectanceatNormalIncidence(data['back_side_visible_reflectance_at_normal_incidence'].to_f)
+    material.setInfraredTransmittanceatNormalIncidence(data['infrared_transmittance_at_normal_incidence'].to_f)
+    material.setFrontSideInfraredHemisphericalEmissivity(data['front_side_infrared_hemispherical_emissivity'].to_f)
+    material.setBackSideInfraredHemisphericalEmissivity(data['back_side_infrared_hemispherical_emissivity'].to_f)
+    material.setConductivity(OpenStudio::convert(data['conductivity'].to_f, 'Btu*in/hr*ft^2*R', 'W/m*K').get)
+    material.setDirtCorrectionFactorforSolarandVisibleTransmittance(data['dirt_correction_factor_for_solar_and_visible_transmittance'].to_f)
+    if /true/i.match(data['solar_diffusing'].to_s)
       material.setSolarDiffusing(true) 
     else
       material.setSolarDiffusing(false)
@@ -198,22 +198,22 @@ def make_construction(construction_name, data, model)
   
   standards_info = construction.standardsInformation
   
-  intended_surface_type = data["intended_surface_type"]
+  intended_surface_type = data['intended_surface_type']
   if not intended_surface_type
-    intended_surface_type = ""
+    intended_surface_type = ''
   end
   standards_info.setIntendedSurfaceType(intended_surface_type)
   
-  standards_construction_type = data["standards_construction_type"]
+  standards_construction_type = data['standards_construction_type']
   if not standards_construction_type
-    standards_construction_type = ""
+    standards_construction_type = ''
   end
   standards_info.setStandardsConstructionType(standards_construction_type)
   
   #TODO: could put color in the spreadsheet
   
   layers = OpenStudio::Model::MaterialVector.new
-  data["materials"].each do |material_name|
+  data['materials'].each do |material_name|
     layers << get_material(material_name, model)
   end
   construction.setLayers(layers)
@@ -242,10 +242,10 @@ def generate_all_constructions(model = nil)
   if model.nil?
     model = OpenStudio::Model::Model.new
   end
-  
-  for construction_name in @constructions.keys.sort
-    get_construction(construction_name, model)  
-  end
+
+  @constructions.keys.sort.each { |construction_name|
+    get_construction(construction_name, model)
+  }
 end
 
 # pass in a specific climate zone here and get the climate zone set to use for generate_construction_set
@@ -270,7 +270,7 @@ def find_climate_zone_set(template, clim, building_type, spc_type)
           if not result
             result = possible_climate_zone_set
           else
-            puts "Error, climate zone contained in multiple climate zone sets"
+            puts 'Error, climate zone contained in multiple climate zone sets'
           end
         end
       end
@@ -286,7 +286,7 @@ def generate_construction_set(template, clim, building_type, spc_type, model = n
     model = OpenStudio::Model::Model.new
   end
 
-  OpenStudio::logFree(OpenStudio::Info, "openstudio.model.constructionsetgenerator", "Generating construction set for #{template}-#{clim}-#{building_type}-#{spc_type}")
+  OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.constructionsetgenerator', "Generating construction set for #{template}-#{clim}-#{building_type}-#{spc_type}")
 
   data = nil
   if tmp1 = @construction_sets[template]
@@ -298,7 +298,7 @@ def generate_construction_set(template, clim, building_type, spc_type, model = n
   end
   
   if data.nil?
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.constructionsetgenerator", "No construction set specified for #{template} #{clim} #{building_type} #{spc_type}")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.constructionsetgenerator', "No construction set specified for #{template} #{clim} #{building_type} #{spc_type}")
     return [nil, nil]
   end
   
@@ -311,94 +311,94 @@ def generate_construction_set(template, clim, building_type, spc_type, model = n
   # exterior surfaces constructions
   exterior_surfaces = OpenStudio::Model::DefaultSurfaceConstructions.new(model)
   construction_set.setDefaultExteriorSurfaceConstructions(exterior_surfaces)
-  if construction_name = data["exterior_floor"]
+  if construction_name = data['exterior_floor']
     exterior_surfaces.setFloorConstruction(get_construction(construction_name, model))
   end      
-  if construction_name = data["exterior_wall"]
+  if construction_name = data['exterior_wall']
     exterior_surfaces.setWallConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["exterior_roof"]
+  if construction_name = data['exterior_roof']
     exterior_surfaces.setRoofCeilingConstruction(get_construction(construction_name, model))
   end    
   
   # interior surfaces constructions
   interior_surfaces = OpenStudio::Model::DefaultSurfaceConstructions.new(model)
   construction_set.setDefaultInteriorSurfaceConstructions(interior_surfaces)
-  if construction_name = data["interior_floor"]
+  if construction_name = data['interior_floor']
     interior_surfaces.setFloorConstruction(get_construction(construction_name, model))
   end      
-  if construction_name = data["interior_wall"]
+  if construction_name = data['interior_wall']
     interior_surfaces.setWallConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["interior_ceiling"]
+  if construction_name = data['interior_ceiling']
     interior_surfaces.setRoofCeilingConstruction(get_construction(construction_name, model))
   end  
   
   # ground contact surfaces constructions
   ground_surfaces = OpenStudio::Model::DefaultSurfaceConstructions.new(model)
   construction_set.setDefaultGroundContactSurfaceConstructions(ground_surfaces)
-  if construction_name = data["ground_contact_floor"]
+  if construction_name = data['ground_contact_floor']
     ground_surfaces.setFloorConstruction(get_construction(construction_name, model))
   end      
-  if construction_name = data["ground_contact_wall"]
+  if construction_name = data['ground_contact_wall']
     ground_surfaces.setWallConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["ground_contact_ceiling"]
+  if construction_name = data['ground_contact_ceiling']
     ground_surfaces.setRoofCeilingConstruction(get_construction(construction_name, model))
   end
   
   # exterior sub surfaces constructions
   exterior_subsurfaces = OpenStudio::Model::DefaultSubSurfaceConstructions.new(model)
   construction_set.setDefaultExteriorSubSurfaceConstructions(exterior_subsurfaces)
-  if construction_name = data["exterior_fixed_window"]
+  if construction_name = data['exterior_fixed_window']
     exterior_subsurfaces.setFixedWindowConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["exterior_operable_window"]
+  if construction_name = data['exterior_operable_window']
     exterior_subsurfaces.setOperableWindowConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["exterior_door"]
+  if construction_name = data['exterior_door']
     exterior_subsurfaces.setDoorConstruction(get_construction(construction_name, model))
   end  
-  if construction_name = data["exterior_glass_door"]
+  if construction_name = data['exterior_glass_door']
     exterior_subsurfaces.setGlassDoorConstruction(get_construction(construction_name, model))
   end  
-  if construction_name = data["exterior_overhead_door"]
+  if construction_name = data['exterior_overhead_door']
     exterior_subsurfaces.setOverheadDoorConstruction(get_construction(construction_name, model))
   end  
-  if construction_name = data["exterior_skylight"]
+  if construction_name = data['exterior_skylight']
     exterior_subsurfaces.setOverheadDoorConstruction(get_construction(construction_name, model))
   end  
-  if construction_name = data["tubular_daylight_dome"]
+  if construction_name = data['tubular_daylight_dome']
     exterior_subsurfaces.setTubularDaylightDomeConstruction(get_construction(construction_name, model))
   end  
-  if construction_name = data["tubular_daylight_diffuser"]
+  if construction_name = data['tubular_daylight_diffuser']
     exterior_subsurfaces.setTubularDaylightDiffuserConstruction(get_construction(construction_name, model))
   end  
   
   # interior sub surfaces constructions
   interior_subsurfaces = OpenStudio::Model::DefaultSubSurfaceConstructions.new(model)
   construction_set.setDefaultInteriorSubSurfaceConstructions(interior_subsurfaces)
-  if construction_name = data["interior_fixed_window"]
+  if construction_name = data['interior_fixed_window']
     interior_subsurfaces.setFixedWindowConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["interior_operable_window"]
+  if construction_name = data['interior_operable_window']
     interior_subsurfaces.setOperableWindowConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["interior_door"]
+  if construction_name = data['interior_door']
     interior_subsurfaces.setDoorConstruction(get_construction(construction_name, model))
   end  
   
   # other constructions
-  if construction_name = data["interior_partition"]
+  if construction_name = data['interior_partition']
     construction_set.setInteriorPartitionConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["space_shading"]
+  if construction_name = data['space_shading']
     construction_set.setSpaceShadingConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["building_shading"]
+  if construction_name = data['building_shading']
     construction_set.setBuildingShadingConstruction(get_construction(construction_name, model))
   end
-  if construction_name = data["site_shading"]
+  if construction_name = data['site_shading']
     construction_set.setSiteShadingConstruction(get_construction(construction_name, model))
   end
  

--- a/create_DOE_prototype_building/resources/Standards.FanConstantVolume.rb
+++ b/create_DOE_prototype_building/resources/Standards.FanConstantVolume.rb
@@ -5,7 +5,7 @@ class OpenStudio::Model::FanConstantVolume
   # Sets the fan motor efficiency based on the standard
   def setStandardEfficiency(template, hvac_standards)
     
-    motors = hvac_standards["motors"]
+    motors = hvac_standards['motors']
     
     # Get the max flow rate from the fan.
     # This expects that the fan is hard sized.
@@ -13,16 +13,16 @@ class OpenStudio::Model::FanConstantVolume
     if maximum_flow_rate_m3_per_s.is_initialized
       maximum_flow_rate_m3_per_s = maximum_flow_rate_m3_per_s.get
     else
-      OpenStudio::logFree(OpenStudio::Warn, "openstudio.hvac_standards.FanConstantVolume", "For #{self.name} max flow rate is not hard sized, cannot apply efficiency standard.")
+      OpenStudio::logFree(OpenStudio::Warn, 'openstudio.hvac_standards.FanConstantVolume', "For #{self.name} max flow rate is not hard sized, cannot apply efficiency standard.")
       return false
     end
     
     # Convert max flow rate to cfm
-    maximum_flow_rate_cfm = OpenStudio.convert(maximum_flow_rate_m3_per_s, "m^3/s", "cfm").get
+    maximum_flow_rate_cfm = OpenStudio.convert(maximum_flow_rate_m3_per_s, 'm^3/s', 'cfm').get
     
     # Get the pressure rise from the fan
     pressure_rise_pa = self.pressureRise
-    pressure_rise_in_h2o = OpenStudio.convert(pressure_rise_pa, "Pa","inH_{2}O").get
+    pressure_rise_in_h2o = OpenStudio.convert(pressure_rise_pa, 'Pa','inH_{2}O').get
     
     # Assume that the fan efficiency is 65% based on
     #TODO need reference
@@ -34,15 +34,15 @@ class OpenStudio::Model::FanConstantVolume
     
     # Find the motor that meets these size criteria
     search_criteria = {
-    "template" => template,
-    "number_of_poles" => 4.0,
-    "type" => "Open Drip-Proof",
+    'template' => template,
+    'number_of_poles' => 4.0,
+    'type' => 'Open Drip-Proof',
     }
     
     motor_properties = find_object(motors, search_criteria, allowed_hp)
   
     # Get the nominal motor efficiency
-    motor_eff = motor_properties["nominal_full_load_efficiency"]
+    motor_eff = motor_properties['nominal_full_load_efficiency']
   
     # Calculate the total fan efficiency
     total_fan_eff = fan_eff * motor_eff
@@ -51,7 +51,7 @@ class OpenStudio::Model::FanConstantVolume
     self.setFanEfficiency(total_fan_eff)
     self.setMotorEfficiency(motor_eff)
     
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.hvac_standards.FanConstantVolume", "For #{template}: #{self.name}: allowed_hp = #{allowed_hp.round}HP; motor eff = #{motor_eff*100}%; total fan eff = #{total_fan_eff*100}%")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.hvac_standards.FanConstantVolume', "For #{template}: #{self.name}: allowed_hp = #{allowed_hp.round}HP; motor eff = #{motor_eff*100}%; total fan eff = #{total_fan_eff*100}%")
     
     return true
     

--- a/create_DOE_prototype_building/resources/Standards.FanVariableVolume.rb
+++ b/create_DOE_prototype_building/resources/Standards.FanVariableVolume.rb
@@ -5,7 +5,7 @@ class OpenStudio::Model::FanVariableVolume
   # Sets the fan motor efficiency based on the standard
   def setStandardEfficiency(template, hvac_standards)
     
-    motors = hvac_standards["motors"]
+    motors = hvac_standards['motors']
     
     # Get the max flow rate from the fan.
     # This expects that the fan is hard sized.
@@ -13,16 +13,16 @@ class OpenStudio::Model::FanVariableVolume
     if maximum_flow_rate_m3_per_s.is_initialized
       maximum_flow_rate_m3_per_s = maximum_flow_rate_m3_per_s.get
     else
-      OpenStudio::logFree(OpenStudio::Warn, "openstudio.hvac_standards.FanVariableVolume", "For #{self.name} max flow rate is not hard sized, cannot apply efficiency standard.")
+      OpenStudio::logFree(OpenStudio::Warn, 'openstudio.hvac_standards.FanVariableVolume', "For #{self.name} max flow rate is not hard sized, cannot apply efficiency standard.")
       return false
     end
     
     # Convert max flow rate to cfm
-    maximum_flow_rate_cfm = OpenStudio.convert(maximum_flow_rate_m3_per_s, "m^3/s", "cfm").get
+    maximum_flow_rate_cfm = OpenStudio.convert(maximum_flow_rate_m3_per_s, 'm^3/s', 'cfm').get
     
     # Get the pressure rise from the fan
     pressure_rise_pa = self.pressureRise
-    pressure_rise_in_h2o = OpenStudio.convert(pressure_rise_pa, "Pa","inH_{2}O").get
+    pressure_rise_in_h2o = OpenStudio.convert(pressure_rise_pa, 'Pa','inH_{2}O').get
     
     # Assume that the fan efficiency is 65% based on
     #TODO need reference
@@ -34,15 +34,15 @@ class OpenStudio::Model::FanVariableVolume
     
     # Find the motor that meets these size criteria
     search_criteria = {
-    "template" => template,
-    "number_of_poles" => 4.0,
-    "type" => "Open Drip-Proof",
+    'template' => template,
+    'number_of_poles' => 4.0,
+    'type' => 'Open Drip-Proof',
     }
     
     motor_properties = find_object(motors, search_criteria, allowed_hp)
   
     # Get the nominal motor efficiency
-    motor_eff = motor_properties["nominal_full_load_efficiency"]
+    motor_eff = motor_properties['nominal_full_load_efficiency']
   
     # Calculate the total fan efficiency
     total_fan_eff = fan_eff * motor_eff
@@ -51,7 +51,7 @@ class OpenStudio::Model::FanVariableVolume
     self.setFanEfficiency(total_fan_eff)
     self.setMotorEfficiency(motor_eff)
     
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.FanVariableVolume", "For #{template}: #{self.name}: allowed_hp = #{allowed_hp.round}HP; motor eff = #{motor_eff*100}%; total fan eff = #{total_fan_eff*100}%")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.FanVariableVolume', "For #{template}: #{self.name}: allowed_hp = #{allowed_hp.round}HP; motor eff = #{motor_eff*100}%; total fan eff = #{total_fan_eff*100}%")
     
     return true
     

--- a/create_DOE_prototype_building/resources/Standards.Model.rb
+++ b/create_DOE_prototype_building/resources/Standards.Model.rb
@@ -12,7 +12,7 @@ class OpenStudio::Model::Model
   
   def applyHVACEfficiencyStandard
     
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Started applying HVAC efficiency standards.")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started applying HVAC efficiency standards.')
     
     ##### Apply equipment efficiencies
     
@@ -29,7 +29,7 @@ class OpenStudio::Model::Model
     # Chillers
     self.getChillerElectricEIRs.sort.each {|obj| obj.setStandardEfficiencyAndCurves(self.template, self.hvac_standards)}
   
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Finished applying HVAC efficiency standards.")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished applying HVAC efficiency standards.')
   
   end 
   

--- a/create_DOE_prototype_building/resources/Standards.SpaceTypeGenerator.rb
+++ b/create_DOE_prototype_building/resources/Standards.SpaceTypeGenerator.rb
@@ -12,18 +12,18 @@ def initialize(path_to_standards_json, path_to_master_schedules_library)
   @standards = {}
   temp = File.read(path_to_standards_json.to_s)
   @standards = JSON.parse(temp)
-  @spc_types = @standards["space_types"]
-  @climate_zone_sets = @standards["climate_zone_sets"]
-  @climate_zones = @standards["climate_zones"]
+  @spc_types = @standards['space_types']
+  @climate_zone_sets = @standards['climate_zone_sets']
+  @climate_zones = @standards['climate_zones']
   if @spc_types.nil? or @climate_zone_sets.nil? or @climate_zones.nil?
-    puts "The space types json file did not load correctly."
+    puts 'The space types json file did not load correctly.'
     exit
   end
   
   #check that the data was loaded correctly
-  check_data = @spc_types["189.1-2009"]["ClimateZone 1-3"]["Hospital"]["Radiology"]["lighting_w_per_area"]
+  check_data = @spc_types['189.1-2009']['ClimateZone 1-3']['Hospital']['Radiology']['lighting_w_per_area']
   unless (check_data-0.36).abs < 0.0000001
-    puts "The space types json file does not have expected content."
+    puts 'The space types json file does not have expected content.'
     exit
   end
 
@@ -38,45 +38,45 @@ end
 
 def make_name(template, clim, building_type, spc_type)
 
-  clim = clim.gsub("ClimateZone ", "CZ")
-  if clim == "CZ1-8"
-    clim = ""
+  clim = clim.gsub('ClimateZone ', 'CZ')
+  if clim == 'CZ1-8'
+    clim = ''
   end
   
-  if building_type == "FullServiceRestaurant"
-    building_type = "FullSrvRest"
-  elsif building_type == "Hospital"
-    building_type = "Hospital"
-  elsif building_type == "LargeHotel"
-    building_type = "LrgHotel"
-  elsif building_type == "LargeOffice"
-    building_type = "LrgOffice"
-  elsif building_type == "MediumOffice"
-    building_type = "MedOffice"
-  elsif building_type == "Mid-riseApartment"
-    building_type = "MidApt"
-  elsif building_type == "Office"
-    building_type = "Office"
-  elsif building_type == "Outpatient"
-    building_type = "Outpatient"
-  elsif building_type == "PrimarySchool"
-    building_type = "PriSchl"
-  elsif building_type == "QuickServiceRestaurant"
-    building_type = "QckSrvRest"
-  elsif building_type == "Retail"
-    building_type = "Retail"
-  elsif building_type == "SecondarySchool"
-    building_type = "SecSchl"
-  elsif building_type == "SmallHotel"
-    building_type = "SmHotel"
-  elsif building_type == "SmallOffice"
-    building_type = "SmOffice"
-  elsif building_type == "StripMall"
-    building_type = "StMall"
-  elsif building_type == "SuperMarket"
-    building_type = "SpMarket"
-  elsif building_type == "Warehouse"
-    building_type = "Warehouse"
+  if building_type == 'FullServiceRestaurant'
+    building_type = 'FullSrvRest'
+  elsif building_type == 'Hospital'
+    building_type = 'Hospital'
+  elsif building_type == 'LargeHotel'
+    building_type = 'LrgHotel'
+  elsif building_type == 'LargeOffice'
+    building_type = 'LrgOffice'
+  elsif building_type == 'MediumOffice'
+    building_type = 'MedOffice'
+  elsif building_type == 'Mid-riseApartment'
+    building_type = 'MidApt'
+  elsif building_type == 'Office'
+    building_type = 'Office'
+  elsif building_type == 'Outpatient'
+    building_type = 'Outpatient'
+  elsif building_type == 'PrimarySchool'
+    building_type = 'PriSchl'
+  elsif building_type == 'QuickServiceRestaurant'
+    building_type = 'QckSrvRest'
+  elsif building_type == 'Retail'
+    building_type = 'Retail'
+  elsif building_type == 'SecondarySchool'
+    building_type = 'SecSchl'
+  elsif building_type == 'SmallHotel'
+    building_type = 'SmHotel'
+  elsif building_type == 'SmallOffice'
+    building_type = 'SmOffice'
+  elsif building_type == 'StripMall'
+    building_type = 'StMall'
+  elsif building_type == 'SuperMarket'
+    building_type = 'SpMarket'
+  elsif building_type == 'Warehouse'
+    building_type = 'Warehouse'
   end
   
   
@@ -109,7 +109,7 @@ end
 # check if a specific climate zone is included in a given climate zone set
 def is_climate_zone_in_climate_zone_set(climate_zone, climate_zone_set)
   if data = @climate_zone_sets[climate_zone_set]
-    if climate_zones = data["climate_zones"]
+    if climate_zones = data['climate_zones']
       if climate_zones.include?(climate_zone)
         return true
       end
@@ -140,7 +140,7 @@ def find_climate_zone_set(template, clim, building_type, spc_type)
           if not result
             result = possible_climate_zone_set
           else
-            puts "Error, climate zone contained in multiple climate zone sets"
+            puts 'Error, climate zone contained in multiple climate zone sets'
           end
         end
       end
@@ -161,14 +161,14 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
   #grabs a schedule with a specific name from the library, clones it into the space type model, and returns itself to the user
   def get_sch_from_lib(sch_name, model)
     #first check model
-    sch = model.getObjectByTypeAndName("OS_Schedule_Ruleset".to_IddObjectType, sch_name)
+    sch = model.getObjectByTypeAndName('OS_Schedule_Ruleset'.to_IddObjectType, sch_name)
     if not sch.empty?
       # could clone here if you really wanted to
       return sch.get.to_ScheduleRuleset.get
     end
     
     #get the correct space type from the library file
-    sch = @schedule_library.getObjectByTypeAndName("OS_Schedule_Ruleset".to_IddObjectType, sch_name)
+    sch = @schedule_library.getObjectByTypeAndName('OS_Schedule_Ruleset'.to_IddObjectType, sch_name)
     
     if sch.empty?
       puts "schedule called '#{sch_name}' not found in master schedule library"
@@ -197,7 +197,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
   end
   
   #set the rendering color of the space type  
-  rgb = @spc_types[template][clim][building_type][spc_type]["rgb"]
+  rgb = @spc_types[template][clim][building_type][spc_type]['rgb']
   rgb = rgb.split('_')
   r = rgb[0].to_i
   g = rgb[1].to_i
@@ -216,21 +216,21 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
   #lighting  
     
     make_lighting = false
-    lighting_per_area = @spc_types[template][clim][building_type][spc_type]["lighting_w_per_area"]
-    lighting_per_person = @spc_types[template][clim][building_type][spc_type]["lighting_w_per_person"]
+    lighting_per_area = @spc_types[template][clim][building_type][spc_type]['lighting_w_per_area']
+    lighting_per_person = @spc_types[template][clim][building_type][spc_type]['lighting_w_per_person']
     unless (lighting_per_area == 0 or lighting_per_area.nil?) then make_lighting = true end
     unless (lighting_per_person == 0 or lighting_per_person.nil?) then make_lighting = true end
     
-    if make_lighting == true
+    if make_lighting
     
       #create the lighting definition 
       lights_def = OpenStudio::Model::LightsDefinition.new(model)
       lights_def.setName("#{name} Lights Definition")
       unless  lighting_per_area == 0 or lighting_per_area.nil?
-        lights_def.setWattsperSpaceFloorArea(OpenStudio::convert(lighting_per_area,"W/ft^2","W/m^2").get)
+        lights_def.setWattsperSpaceFloorArea(OpenStudio::convert(lighting_per_area,'W/ft^2','W/m^2').get)
       end
       unless lighting_per_person == 0 or lighting_per_person.nil?
-        lights_def.setWattsperPerson(OpenStudio::convert(lighting_per_person,"W/person","W/person").get)
+        lights_def.setWattsperPerson(OpenStudio::convert(lighting_per_person,'W/person','W/person').get)
       end
 
       #create the lighting instance and hook it up to the space type
@@ -239,7 +239,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
       lights.setSpaceType(space_type)  
       
       #get the lighting schedule and set it as the default
-      lighting_sch = @spc_types[template][clim][building_type][spc_type]["lighting_sch"]
+      lighting_sch = @spc_types[template][clim][building_type][spc_type]['lighting_sch']
       unless lighting_sch.nil?
         default_sch_set.setLightingSchedule(get_sch_from_lib(lighting_sch, model))
       end    
@@ -249,9 +249,9 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
   #ventilation
 
     make_ventilation = false
-    ventilation_per_area = @spc_types[template][clim][building_type][spc_type]["ventilation_per_area"]  
-    ventilation_per_person = @spc_types[template][clim][building_type][spc_type]["ventilation_per_person"]
-    ventilation_ach = @spc_types[template][clim][building_type][spc_type]["ventilation_ach"]
+    ventilation_per_area = @spc_types[template][clim][building_type][spc_type]['ventilation_per_area']
+    ventilation_per_person = @spc_types[template][clim][building_type][spc_type]['ventilation_per_person']
+    ventilation_ach = @spc_types[template][clim][building_type][spc_type]['ventilation_ach']
     unless (ventilation_per_area  == 0 or ventilation_per_area.nil?) then make_ventilation = true  end
     unless(ventilation_per_person == 0 or ventilation_per_person.nil?) then make_ventilation = true end
     unless(ventilation_ach == 0 or ventilation_ach.nil?) then make_ventilation = true end
@@ -264,10 +264,10 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
       space_type.setDesignSpecificationOutdoorAir(ventilation)
       ventilation.setOutdoorAirMethod("Sum")
       unless ventilation_per_area  == 0 or ventilation_per_area.nil? 
-        ventilation.setOutdoorAirFlowperFloorArea(OpenStudio::convert(ventilation_per_area,"ft^3/min*ft^2","m^3/s*m^2").get)
+        ventilation.setOutdoorAirFlowperFloorArea(OpenStudio::convert(ventilation_per_area,'ft^3/min*ft^2','m^3/s*m^2').get)
       end
       unless ventilation_per_person == 0 or ventilation_per_person.nil?
-        ventilation.setOutdoorAirFlowperPerson(OpenStudio::convert(ventilation_per_person,"ft^3/min*person","m^3/s*person").get)
+        ventilation.setOutdoorAirFlowperPerson(OpenStudio::convert(ventilation_per_person,'ft^3/min*person','m^3/s*person').get)
       end
       unless ventilation_ach == 0 or ventilation_ach.nil?
         ventilation.setOutdoorAirFlowAirChangesperHour(ventilation_ach)
@@ -278,7 +278,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
   #occupancy
 
     make_people = false
-    occupancy_per_area = @spc_types[template][clim][building_type][spc_type]["occupancy_per_area"]
+    occupancy_per_area = @spc_types[template][clim][building_type][spc_type]['occupancy_per_area']
     unless(occupancy_per_area == 0 or occupancy_per_area.nil?) then make_people = true end
     
     if make_people == true
@@ -287,7 +287,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
       people_def = OpenStudio::Model::PeopleDefinition.new(model)
       people_def.setName("#{name} People Definition")
       unless  occupancy_per_area == 0 or occupancy_per_area.nil?
-        people_def.setPeopleperSpaceFloorArea(OpenStudio::convert(occupancy_per_area/1000,"people/ft^2","people/m^2").get)
+        people_def.setPeopleperSpaceFloorArea(OpenStudio::convert(occupancy_per_area/1000,'people/ft^2','people/m^2').get)
       end    
       
       #create the people instance and hook it up to the space type
@@ -296,11 +296,11 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
       people.setSpaceType(space_type)
       
       #get the occupancy and occupant activity schedules from the library and set as the default
-      occupancy_sch = @spc_types[template][clim][building_type][spc_type]["occupancy_sch"]
+      occupancy_sch = @spc_types[template][clim][building_type][spc_type]['occupancy_sch']
       unless occupancy_sch.nil?
         default_sch_set.setNumberofPeopleSchedule(get_sch_from_lib(occupancy_sch, model))
       end
-      occupancy_activity_sch = @spc_types[template][clim][building_type][spc_type]["occupancy_activity_sch"]  
+      occupancy_activity_sch = @spc_types[template][clim][building_type][spc_type]['occupancy_activity_sch']
       unless occupancy_activity_sch.nil?
         default_sch_set.setPeopleActivityLevelSchedule(get_sch_from_lib(occupancy_activity_sch, model))
       end
@@ -310,7 +310,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
   #infiltration
 
     make_infiltration = false
-    infiltration_per_area_ext = @spc_types[template][clim][building_type][spc_type]["infiltration_per_area_ext"]      
+    infiltration_per_area_ext = @spc_types[template][clim][building_type][spc_type]['infiltration_per_area_ext']
     unless(infiltration_per_area_ext == 0 or infiltration_per_area_ext.nil?) then make_infiltration = true end
 
     if make_infiltration == true
@@ -320,11 +320,11 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
       infiltration.setName("#{name} Infiltration")
       infiltration.setSpaceType(space_type)
       unless infiltration_per_area_ext == 0 or infiltration_per_area_ext.nil?
-        infiltration.setFlowperExteriorSurfaceArea(OpenStudio::convert(infiltration_per_area_ext,"ft^3/min*ft^2","m^3/s*m^2").get)
+        infiltration.setFlowperExteriorSurfaceArea(OpenStudio::convert(infiltration_per_area_ext,'ft^3/min*ft^2','m^3/s*m^2').get)
       end
       
       #get the infiltration schedule from the library and set as the default
-      infiltration_sch = @spc_types[template][clim][building_type][spc_type]["infiltration_sch"]
+      infiltration_sch = @spc_types[template][clim][building_type][spc_type]['infiltration_sch']
       unless infiltration_sch.nil?
         default_sch_set.setInfiltrationSchedule(get_sch_from_lib(infiltration_sch, model))
       end
@@ -334,7 +334,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
   #electric equipment
 
     make_electric_equipment = false
-    elec_equip_per_area = @spc_types[template][clim][building_type][spc_type]["elec_equip_per_area"]
+    elec_equip_per_area = @spc_types[template][clim][building_type][spc_type]['elec_equip_per_area']
     unless(elec_equip_per_area == 0 or elec_equip_per_area.nil?) then make_electric_equipment = true end
     
     if make_electric_equipment == true
@@ -343,7 +343,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
       elec_equip_def = OpenStudio::Model::ElectricEquipmentDefinition.new(model)
       elec_equip_def.setName("#{name} Electric Equipment Definition")  
       unless  elec_equip_per_area == 0 or elec_equip_per_area.nil?
-        elec_equip_def.setWattsperSpaceFloorArea(OpenStudio::convert(elec_equip_per_area,"W/ft^2","W/m^2").get)
+        elec_equip_def.setWattsperSpaceFloorArea(OpenStudio::convert(elec_equip_per_area,'W/ft^2','W/m^2').get)
       end
         
       #create the electric equipment instance and hook it up to the space type
@@ -352,7 +352,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
       elec_equip.setSpaceType(space_type)
       
       #get the electric equipment schedule from the library and set as the default
-      elec_equip_sch = @spc_types[template][clim][building_type][spc_type]["elec_equip_sch"]
+      elec_equip_sch = @spc_types[template][clim][building_type][spc_type]['elec_equip_sch']
       unless elec_equip_sch.nil?
         default_sch_set.setElectricEquipmentSchedule(get_sch_from_lib(elec_equip_sch, model))
       end
@@ -362,7 +362,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
   #gas equipment
     
     make_gas_equipment = false
-    gas_equip_per_area = @spc_types[template][clim][building_type][spc_type]["gas_equip_per_area"]
+    gas_equip_per_area = @spc_types[template][clim][building_type][spc_type]['gas_equip_per_area']
     unless  (gas_equip_per_area == 0 or gas_equip_per_area.nil?) then make_gas_equipment = true end
     
     if make_gas_equipment == true
@@ -371,7 +371,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
       gas_equip_def = OpenStudio::Model::GasEquipmentDefinition.new(model)
       gas_equip_def.setName("#{name} Gas Equipment Definition")
       unless  gas_equip_per_area == 0 or gas_equip_per_area.nil?
-        gas_equip_def.setWattsperSpaceFloorArea(OpenStudio::convert(gas_equip_per_area,"Btu/hr*ft^2","W/m^2").get)
+        gas_equip_def.setWattsperSpaceFloorArea(OpenStudio::convert(gas_equip_per_area,'Btu/hr*ft^2','W/m^2').get)
       end
       
       #create the gas equipment instance and hook it up to the space type
@@ -380,7 +380,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
       gas_equip.setSpaceType(space_type)
       
       #get the gas equipment schedule from the library and set as the default
-      gas_equip_sch = @spc_types[template][clim][building_type][spc_type]["gas_equip_sch"]
+      gas_equip_sch = @spc_types[template][clim][building_type][spc_type]['gas_equip_sch']
       unless gas_equip_sch.nil?
         default_sch_set.setGasEquipmentSchedule(get_sch_from_lib(gas_equip_sch, model))
       end
@@ -390,12 +390,12 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
     thermostat = OpenStudio::Model::ThermostatSetpointDualSetpoint.new(model)
     thermostat.setName("#{name} Thermostat")
     
-    heating_setpoint_sch = @spc_types[template][clim][building_type][spc_type]["heating_setpoint_sch"]
+    heating_setpoint_sch = @spc_types[template][clim][building_type][spc_type]['heating_setpoint_sch']
     unless heating_setpoint_sch.nil?
       thermostat.setHeatingSetpointTemperatureSchedule(get_sch_from_lib(heating_setpoint_sch, model))
     end
    
-    cooling_setpoint_sch = @spc_types[template][clim][building_type][spc_type]["cooling_setpoint_sch"]
+    cooling_setpoint_sch = @spc_types[template][clim][building_type][spc_type]['cooling_setpoint_sch']
     unless cooling_setpoint_sch.nil?
       thermostat.setCoolingSetpointTemperatureSchedule(get_sch_from_lib(cooling_setpoint_sch, model))
     end

--- a/create_DOE_prototype_building/resources/Standards.SpaceTypeGenerator.rb
+++ b/create_DOE_prototype_building/resources/Standards.SpaceTypeGenerator.rb
@@ -194,10 +194,12 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
   if @spc_types[template][clim][building_type][spc_type].nil?
     puts "Error - Space Type #{template}:#{clim}:#{building_type}:#{spc_type} Not Found."
     return false
+  else
+    space_types = @spc_types[template][clim][building_type][spc_type]
   end
   
   #set the rendering color of the space type  
-  rgb = @spc_types[template][clim][building_type][spc_type]['rgb']
+  rgb = space_types['rgb']
   rgb = rgb.split('_')
   r = rgb[0].to_i
   g = rgb[1].to_i
@@ -216,8 +218,8 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
   #lighting  
     
     make_lighting = false
-    lighting_per_area = @spc_types[template][clim][building_type][spc_type]['lighting_w_per_area']
-    lighting_per_person = @spc_types[template][clim][building_type][spc_type]['lighting_w_per_person']
+    lighting_per_area = space_types['lighting_w_per_area']
+    lighting_per_person = space_types['lighting_w_per_person']
     unless (lighting_per_area == 0 or lighting_per_area.nil?) then make_lighting = true end
     unless (lighting_per_person == 0 or lighting_per_person.nil?) then make_lighting = true end
     
@@ -239,7 +241,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
       lights.setSpaceType(space_type)  
       
       #get the lighting schedule and set it as the default
-      lighting_sch = @spc_types[template][clim][building_type][spc_type]['lighting_sch']
+      lighting_sch = space_types['lighting_sch']
       unless lighting_sch.nil?
         default_sch_set.setLightingSchedule(get_sch_from_lib(lighting_sch, model))
       end    
@@ -249,9 +251,9 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
   #ventilation
 
     make_ventilation = false
-    ventilation_per_area = @spc_types[template][clim][building_type][spc_type]['ventilation_per_area']
-    ventilation_per_person = @spc_types[template][clim][building_type][spc_type]['ventilation_per_person']
-    ventilation_ach = @spc_types[template][clim][building_type][spc_type]['ventilation_ach']
+    ventilation_per_area = space_types['ventilation_per_area']
+    ventilation_per_person = space_types['ventilation_per_person']
+    ventilation_ach = space_types['ventilation_ach']
     unless (ventilation_per_area  == 0 or ventilation_per_area.nil?) then make_ventilation = true  end
     unless(ventilation_per_person == 0 or ventilation_per_person.nil?) then make_ventilation = true end
     unless(ventilation_ach == 0 or ventilation_ach.nil?) then make_ventilation = true end
@@ -278,7 +280,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
   #occupancy
 
     make_people = false
-    occupancy_per_area = @spc_types[template][clim][building_type][spc_type]['occupancy_per_area']
+    occupancy_per_area = space_types['occupancy_per_area']
     unless(occupancy_per_area == 0 or occupancy_per_area.nil?) then make_people = true end
     
     if make_people == true
@@ -296,11 +298,11 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
       people.setSpaceType(space_type)
       
       #get the occupancy and occupant activity schedules from the library and set as the default
-      occupancy_sch = @spc_types[template][clim][building_type][spc_type]['occupancy_sch']
+      occupancy_sch = space_types['occupancy_sch']
       unless occupancy_sch.nil?
         default_sch_set.setNumberofPeopleSchedule(get_sch_from_lib(occupancy_sch, model))
       end
-      occupancy_activity_sch = @spc_types[template][clim][building_type][spc_type]['occupancy_activity_sch']
+      occupancy_activity_sch = space_types['occupancy_activity_sch']
       unless occupancy_activity_sch.nil?
         default_sch_set.setPeopleActivityLevelSchedule(get_sch_from_lib(occupancy_activity_sch, model))
       end
@@ -310,7 +312,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
   #infiltration
 
     make_infiltration = false
-    infiltration_per_area_ext = @spc_types[template][clim][building_type][spc_type]['infiltration_per_area_ext']
+    infiltration_per_area_ext = space_types['infiltration_per_area_ext']
     unless(infiltration_per_area_ext == 0 or infiltration_per_area_ext.nil?) then make_infiltration = true end
 
     if make_infiltration == true
@@ -324,7 +326,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
       end
       
       #get the infiltration schedule from the library and set as the default
-      infiltration_sch = @spc_types[template][clim][building_type][spc_type]['infiltration_sch']
+      infiltration_sch = space_types['infiltration_sch']
       unless infiltration_sch.nil?
         default_sch_set.setInfiltrationSchedule(get_sch_from_lib(infiltration_sch, model))
       end
@@ -334,7 +336,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
   #electric equipment
 
     make_electric_equipment = false
-    elec_equip_per_area = @spc_types[template][clim][building_type][spc_type]['elec_equip_per_area']
+    elec_equip_per_area = space_types['elec_equip_per_area']
     unless(elec_equip_per_area == 0 or elec_equip_per_area.nil?) then make_electric_equipment = true end
     
     if make_electric_equipment == true
@@ -352,7 +354,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
       elec_equip.setSpaceType(space_type)
       
       #get the electric equipment schedule from the library and set as the default
-      elec_equip_sch = @spc_types[template][clim][building_type][spc_type]['elec_equip_sch']
+      elec_equip_sch = space_types['elec_equip_sch']
       unless elec_equip_sch.nil?
         default_sch_set.setElectricEquipmentSchedule(get_sch_from_lib(elec_equip_sch, model))
       end
@@ -362,7 +364,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
   #gas equipment
     
     make_gas_equipment = false
-    gas_equip_per_area = @spc_types[template][clim][building_type][spc_type]['gas_equip_per_area']
+    gas_equip_per_area = space_types['gas_equip_per_area']
     unless  (gas_equip_per_area == 0 or gas_equip_per_area.nil?) then make_gas_equipment = true end
     
     if make_gas_equipment == true
@@ -380,7 +382,7 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
       gas_equip.setSpaceType(space_type)
       
       #get the gas equipment schedule from the library and set as the default
-      gas_equip_sch = @spc_types[template][clim][building_type][spc_type]['gas_equip_sch']
+      gas_equip_sch = space_types['gas_equip_sch']
       unless gas_equip_sch.nil?
         default_sch_set.setGasEquipmentSchedule(get_sch_from_lib(gas_equip_sch, model))
       end
@@ -390,12 +392,12 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
     thermostat = OpenStudio::Model::ThermostatSetpointDualSetpoint.new(model)
     thermostat.setName("#{name} Thermostat")
     
-    heating_setpoint_sch = @spc_types[template][clim][building_type][spc_type]['heating_setpoint_sch']
+    heating_setpoint_sch = space_types['heating_setpoint_sch']
     unless heating_setpoint_sch.nil?
       thermostat.setHeatingSetpointTemperatureSchedule(get_sch_from_lib(heating_setpoint_sch, model))
     end
    
-    cooling_setpoint_sch = @spc_types[template][clim][building_type][spc_type]['cooling_setpoint_sch']
+    cooling_setpoint_sch = space_types['cooling_setpoint_sch']
     unless cooling_setpoint_sch.nil?
       thermostat.setCoolingSetpointTemperatureSchedule(get_sch_from_lib(cooling_setpoint_sch, model))
     end
@@ -451,13 +453,13 @@ def generate_space_type(template, clim, building_type, spc_type, model = nil)
   component.add_attribute("OpenStudio Type", space_type.iddObjectType.valueDescription, "")
               
   #add other attributes
-  component.add_attribute("Lighting Standard",  @spc_types[template][clim][building_type][spc_type]["lighting_standard"], "")
-  component.add_attribute("Lighting Primary Space Type",  @spc_types[template][clim][building_type][spc_type]["lighting_pri_spc_type"], "")
-  component.add_attribute("Lighting Secondary Space Type",  @spc_types[template][clim][building_type][spc_type]["lighting_sec_spc_type"], "")
+  component.add_attribute("Lighting Standard",  space_types["lighting_standard"], "")
+  component.add_attribute("Lighting Primary Space Type",  space_types["lighting_pri_spc_type"], "")
+  component.add_attribute("Lighting Secondary Space Type",  space_types["lighting_sec_spc_type"], "")
 
-  component.add_attribute("Ventilation Standard",  @spc_types[template][clim][building_type][spc_type]["ventilation_standard"], "")
-  component.add_attribute("Ventilation Primary Space Type",  @spc_types[template][clim][building_type][spc_type]["ventilation_pri_spc_type"], "")
-  component.add_attribute("Ventilation Secondary Space Type",  @spc_types[template][clim][building_type][spc_type]["ventilation_sec_spc_type"], "")
+  component.add_attribute("Ventilation Standard",  space_types["ventilation_standard"], "")
+  component.add_attribute("Ventilation Primary Space Type",  space_types["ventilation_pri_spc_type"], "")
+  component.add_attribute("Ventilation Secondary Space Type",  space_types["ventilation_sec_spc_type"], "")
 
   component.add_attribute("Occupancy Standard",  "NREL reference buildings", "")
   component.add_attribute("Occupancy Primary Space Type",  building_type, "")

--- a/create_DOE_prototype_building/resources/Weather.Model.rb
+++ b/create_DOE_prototype_building/resources/Weather.Model.rb
@@ -9,29 +9,29 @@ class OpenStudio::Model::Model
 
     require_relative 'Weather.stat_file'
     
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Started adding weather file for climate zone: #{climate_zone}.")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Started adding weather file for climate zone: #{climate_zone}.")
     
     # Define the weather file for each climate zone
     climate_zone_weather_file_map = {
-      "ASHRAE 169-2006-1A" => "USA_FL_Miami.Intl.AP.722020_TMY3.epw",
-      "ASHRAE 169-2006-1B" => "TODO Riyadh.epw",
-      "ASHRAE 169-2006-2A" => "USA_TX_Houston-Bush.Intercontinental.AP.722430_TMY3.epw",
-      "ASHRAE 169-2006-2B" => "USA_AZ_Phoenix-Sky.Harbor.Intl.AP.722780_TMY3.epw",
-      "ASHRAE 169-2006-3A" => "USA_TN_Memphis.Intl.AP.723340_TMY3.epw",
-      "ASHRAE 169-2006-3B" => "USA_TX_El.Paso.Intl.AP.722700_TMY3.epw",
-      "ASHRAE 169-2006-3C" => "USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw",
-      "ASHRAE 169-2006-4A" => "USA_MD_Baltimore-Washington.Intl.AP.724060_TMY3.epw",
-      "ASHRAE 169-2006-4B" => "USA_NM_Albuquerque.Intl.AP.723650_TMY3.epw",
-      "ASHRAE 169-2006-4C" => "USA_OR_Salem-McNary.Field.726940_TMY3.epw",
-      "ASHRAE 169-2006-5A" => "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw",
-      "ASHRAE 169-2006-5B" => "USA_ID_Boise.Air.Terminal.726810_TMY3.epw",
-      "ASHRAE 169-2006-5C" => "TODO Vancouver.epw",
-      "ASHRAE 169-2006-6A" => "USA_VT_Burlington.Intl.AP.726170_TMY3.epw",
-      "ASHRAE 169-2006-6B" => "USA_MT_Helena.Rgnl.AP.727720_TMY3.epw",
-      "ASHRAE 169-2006-7A" => "USA_MN_Duluth.Intl.AP.727450_TMY3.epw",
-      "ASHRAE 169-2006-7B" => "USA_MN_Duluth.Intl.AP.727450_TMY3.epw",
-      "ASHRAE 169-2006-8A" => "USA_AK_Fairbanks.Intl.AP.702610_TMY3.epw",
-      "ASHRAE 169-2006-8B" => "USA_AK_Fairbanks.Intl.AP.702610_TMY3.epw"
+      'ASHRAE 169-2006-1A' => 'USA_FL_Miami.Intl.AP.722020_TMY3.epw',
+      'ASHRAE 169-2006-1B' => 'TODO Riyadh.epw',
+      'ASHRAE 169-2006-2A' => 'USA_TX_Houston-Bush.Intercontinental.AP.722430_TMY3.epw',
+      'ASHRAE 169-2006-2B' => 'USA_AZ_Phoenix-Sky.Harbor.Intl.AP.722780_TMY3.epw',
+      'ASHRAE 169-2006-3A' => 'USA_TN_Memphis.Intl.AP.723340_TMY3.epw',
+      'ASHRAE 169-2006-3B' => 'USA_TX_El.Paso.Intl.AP.722700_TMY3.epw',
+      'ASHRAE 169-2006-3C' => 'USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw',
+      'ASHRAE 169-2006-4A' => 'USA_MD_Baltimore-Washington.Intl.AP.724060_TMY3.epw',
+      'ASHRAE 169-2006-4B' => 'USA_NM_Albuquerque.Intl.AP.723650_TMY3.epw',
+      'ASHRAE 169-2006-4C' => 'USA_OR_Salem-McNary.Field.726940_TMY3.epw',
+      'ASHRAE 169-2006-5A' => 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw',
+      'ASHRAE 169-2006-5B' => 'USA_ID_Boise.Air.Terminal.726810_TMY3.epw',
+      'ASHRAE 169-2006-5C' => 'TODO Vancouver.epw',
+      'ASHRAE 169-2006-6A' => 'USA_VT_Burlington.Intl.AP.726170_TMY3.epw',
+      'ASHRAE 169-2006-6B' => 'USA_MT_Helena.Rgnl.AP.727720_TMY3.epw',
+      'ASHRAE 169-2006-7A' => 'USA_MN_Duluth.Intl.AP.727450_TMY3.epw',
+      'ASHRAE 169-2006-7B' => 'USA_MN_Duluth.Intl.AP.727450_TMY3.epw',
+      'ASHRAE 169-2006-8A' => 'USA_AK_Fairbanks.Intl.AP.702610_TMY3.epw',
+      'ASHRAE 169-2006-8B' => 'USA_AK_Fairbanks.Intl.AP.702610_TMY3.epw'
     }
 
     # Define where the weather files live
@@ -41,7 +41,7 @@ class OpenStudio::Model::Model
     # Get the weather file name from the hash
     weather_file_name = climate_zone_weather_file_map[climate_zone]
     if weather_file_name.nil?
-      OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "Could not determine the weather file for climate zone: #{climate_zone}.")
+      OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', "Could not determine the weather file for climate zone: #{climate_zone}.")
       return false
     end
     
@@ -92,7 +92,7 @@ class OpenStudio::Model::Model
       #OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Mean dry bulb is #{stat_file.mean_dry_bulb}")
       #OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Delta dry bulb is #{stat_file.delta_dry_bulb}")
     else
-      OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "Could not find .stat file for: #{stat_filename}.")
+      OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', "Could not find .stat file for: #{stat_filename}.")
       return false
     end
 
@@ -104,20 +104,20 @@ class OpenStudio::Model::Model
     ddy_file = "#{File.join(File.dirname(weather_file), File.basename(weather_file, '.*'))}.ddy"
     if File.exist? ddy_file
       ddy_model = OpenStudio::EnergyPlus.loadAndTranslateIdf(ddy_file).get
-      ddy_model.getObjectsByType("OS:SizingPeriod:DesignDay".to_IddObjectType).each do |d|
+      ddy_model.getObjectsByType('OS:SizingPeriod:DesignDay'.to_IddObjectType).each do |d|
         # Import the 99.6% Heating and 0.4% Cooling design days
         ddy_list = /(Htg 99.6. Condns DB)|(Clg .4. Condns WB=>MDB)|(Clg .4% Condns DB=>MWB)/
         if d.name.get =~ ddy_list       
           self.addObject(d.clone)
-          #OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Added #{d.name} design day.")
+          #OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Added #{d.name} design day.")
         end
       end
     else
-      OpenStudio::logFree(OpenStudio::Error, "openstudio.model.Model", "Could not find .stat file for: #{stat_filename}.")
+      OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', "Could not find .stat file for: #{stat_filename}.")
       return false
     end
 
-    OpenStudio::logFree(OpenStudio::Info, "openstudio.model.Model", "Finished adding weather file for climate zone: #{climate_zone}.")
+    OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Finished adding weather file for climate zone: #{climate_zone}.")
     
     return true
       

--- a/create_DOE_prototype_building/resources/Weather.stat_file.rb
+++ b/create_DOE_prototype_building/resources/Weather.stat_file.rb
@@ -60,7 +60,7 @@ module EnergyPlus
         @monthly_dry_bulb.each { |db| sum += db }
         mean = sum/@monthly_dry_bulb.size
       else
-        mean = ""
+        mean = ''
       end
 
       mean
@@ -71,7 +71,7 @@ module EnergyPlus
       if not @monthly_dry_bulb.empty? then
         delta_t = @monthly_dry_bulb.max-@monthly_dry_bulb.min
       else
-        delta_t = ""
+        delta_t = ''
       end
 
       delta_t
@@ -83,7 +83,7 @@ module EnergyPlus
     def init
       if @path.exist?
         File.open(@path) do |f|
-          text = f.read.force_encoding("iso-8859-1")
+          text = f.read.force_encoding('iso-8859-1')
           parse(text)
         end
       end

--- a/create_DOE_prototype_building/tests/create_DOE_prototype_building_Test.rb
+++ b/create_DOE_prototype_building/tests/create_DOE_prototype_building_Test.rb
@@ -176,7 +176,6 @@ class CreateDOEPrototypeBuildingTest < MiniTest::Test
     failures = []
     
     # Load the legacy idf results JSON file into a ruby hash
-    legacy_idf_results = {}
     temp = File.read("#{Dir.pwd}/legacy_idf_results.json")
     legacy_idf_results = JSON.parse(temp)    
          

--- a/create_DOE_prototype_building/tests/create_DOE_prototype_building_Test.rb
+++ b/create_DOE_prototype_building/tests/create_DOE_prototype_building_Test.rb
@@ -47,20 +47,20 @@ class CreateDOEPrototypeBuildingTest < MiniTest::Test
           argument_map = OpenStudio::Ruleset::OSArgumentMap.new
           building_type_arg = arguments[0].clone
           assert(building_type_arg.setValue(building_type))
-          argument_map["building_type"] = building_type_arg
+          argument_map['building_type'] = building_type_arg
           
           building_vintage_arg = arguments[1].clone
           assert(building_vintage_arg.setValue(building_vintage))
-          argument_map["building_vintage"] = building_vintage_arg
+          argument_map['building_vintage'] = building_vintage_arg
 
           climate_zone_arg = arguments[2].clone
           assert(climate_zone_arg.setValue(climate_zone))
-          argument_map["climate_zone"] = climate_zone_arg
+          argument_map['climate_zone'] = climate_zone_arg
 
           measure.run(model, runner, argument_map)
           result = runner.result
           show_output(result)
-          if !result.value.valueName == "Success"
+          if result.value.valueName != 'Success'
             failures << "Error - #{model_name} - Model was not created successfully."
           end
           
@@ -102,8 +102,8 @@ class CreateDOEPrototypeBuildingTest < MiniTest::Test
           model_path_string = "#{model_directory}/final.osm"
           model_path = OpenStudio::Path.new(model_path_string)
           if OpenStudio::exists(model_path)
-            versionTranslator = OpenStudio::OSVersion::VersionTranslator.new 
-            model = versionTranslator.loadModel(model_path)
+            version_translator = OpenStudio::OSVersion::VersionTranslator.new
+            model = version_translator.loadModel(model_path)
             if model.empty?
               failures << "Error - #{model_name} - Version translation failed"
               return failures
@@ -181,10 +181,10 @@ class CreateDOEPrototypeBuildingTest < MiniTest::Test
     legacy_idf_results = JSON.parse(temp)    
          
     # List of all fuel types
-    fuel_types = ["Electricity", "Natural Gas", "Additional Fuel", "District Cooling", "District Heating", "Water"]
+    fuel_types = ['Electricity', 'Natural Gas', 'Additional Fuel', 'District Cooling', 'District Heating', 'Water']
 
     # List of all end uses
-    end_uses = ["Heating", "Cooling", "Interior Lighting", "Exterior Lighting", "Interior Equipment", "Exterior Equipment", "Fans", "Pumps", "Heat Rejection","Humidification", "Heat Recovery", "Water Systems", "Refrigeration", "Generators"]
+    end_uses = ['Heating', 'Cooling', 'Interior Lighting', 'Exterior Lighting', 'Interior Equipment', 'Exterior Equipment', 'Fans', 'Pumps', 'Heat Rejection','Humidification', 'Heat Recovery', 'Water Systems', 'Refrigeration', 'Generators']
 
     # Create a CSV to store the results
     ### Junk csv_string = CSV.generate do |csv| end
@@ -225,9 +225,9 @@ class CreateDOEPrototypeBuildingTest < MiniTest::Test
                 end
                 
                 # Select the correct units based on fuel type
-                units = "GJ"
-                if fuel_type == "Water"
-                  units = "m3"
+                units = 'GJ'
+                if fuel_type == 'Water'
+                  units = 'm3'
                 end
                 
                 # End use breakdown query
@@ -264,9 +264,9 @@ class CreateDOEPrototypeBuildingTest < MiniTest::Test
                 end
                 
                 # Record the values
-                results_hash[building_type][building_vintage][climate_zone][fuel_type][end_use]["Legacy Val"] = legacy_val.round(2)
-                results_hash[building_type][building_vintage][climate_zone][fuel_type][end_use]["OpenStudio Val"] = osm_val.round(2)
-                results_hash[building_type][building_vintage][climate_zone][fuel_type][end_use]["Percent Error"] = percent_error.round(2)
+                results_hash[building_type][building_vintage][climate_zone][fuel_type][end_use]['Legacy Val'] = legacy_val.round(2)
+                results_hash[building_type][building_vintage][climate_zone][fuel_type][end_use]['OpenStudio Val'] = osm_val.round(2)
+                results_hash[building_type][building_vintage][climate_zone][fuel_type][end_use]['Percent Error'] = percent_error.round(2)
                 
               end # Next end use
             end # Next fuel type
@@ -288,9 +288,9 @@ class CreateDOEPrototypeBuildingTest < MiniTest::Test
   # Test the Secondary School in the PTool vintages and climate zones
   def dont_test_secondary_school_ptool
 
-    bldg_types = ["SecondarySchool"]
-    vintages = ["90.1-2010"] #, "DOE Ref Pre-1980", "DOE Ref 1980-2004"]
-    climate_zones = ["ASHRAE 169-2006-2A"]#, "ASHRAE 169-2006-3B", "ASHRAE 169-2006-4A", "ASHRAE 169-2006-5A"]
+    bldg_types = ['SecondarySchool']
+    vintages = ['90.1-2010'] #, 'DOE Ref Pre-1980', 'DOE Ref 1980-2004']
+    climate_zones = ['ASHRAE 169-2006-2A']#, 'ASHRAE 169-2006-3B', 'ASHRAE 169-2006-4A', 'ASHRAE 169-2006-5A']
 
     all_failures = []
     
@@ -317,9 +317,9 @@ class CreateDOEPrototypeBuildingTest < MiniTest::Test
   # Test the Small Office in the PTool vintages and climate zones
   def test_small_office_ptool
 
-    bldg_types = ["SmallOffice"]#,"SecondarySchool"]
-    vintages = ["90.1-2010", "DOE Ref Pre-1980", "DOE Ref 1980-2004"]
-    climate_zones = ["ASHRAE 169-2006-2A"]#, "ASHRAE 169-2006-3B", "ASHRAE 169-2006-4A", "ASHRAE 169-2006-5A"]
+    bldg_types = ['SmallOffice']#,'SecondarySchool']
+    vintages = ['90.1-2010', 'DOE Ref Pre-1980', 'DOE Ref 1980-2004']
+    climate_zones = ['ASHRAE 169-2006-2A']#, 'ASHRAE 169-2006-3B', 'ASHRAE 169-2006-4A', 'ASHRAE 169-2006-5A']
 
     all_failures = []
     


### PR DESCRIPTION
@asparke2 @YixingChen 

Some style and code clean up.

I updated strip_model to require a passed in argument to the script. You would use it like 'ruby -I ~/osbuilds/nrel_develop/OSCore-prefix/src/OSCore-build/ruby/ Prototype.strip_model.rb Geometry.medium_office.osm' at least on my Mac using a custom OS build. Basically you have to pass in an absolute path or relative path to the OSM file.

I will add more geometries as well as update the strip_model to only leave surfaces, subsurfaces, and spaces.